### PR TITLE
BM-Autofill: Aktivierung nur bei Bedarf (Plan A/Plan B) + Extension-Version auf 2.1.0 angehoben

### DIFF
--- a/pars-pro-toto-BM-Autofill-chrome-extension/content/tecis-bm-gespraechsnotiz-autofill.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/content/tecis-bm-gespraechsnotiz-autofill.js
@@ -926,57 +926,68 @@ function extensionFetchJson(url, { method = 'GET', headers = {}, body = null, wi
         let pageData;
         const wibiid = decodeBase64Url(qs.get('wibiid') || '').trim();
 
+        // Schritt 1: Lade die grundlegenden Dokument-Daten. Dies ist immer notwendig.
         try {
-            // Schritt 1: Lade die JSON-Struktur des Dokuments
-            try {
-                const timeoutPromise = new Promise((_, reject) => setTimeout(() => reject("Timeout"), 5000));
-                pageData = await Promise.race([documentJsonPromise, timeoutPromise]);
-            } catch (err) {
-                console.log("Interceptor timed out or failed, trying manual fetch...");
-                const docId = qs.get('documentid');
-                if (docId) {
-                    const fallbackUrl = `https://bm.bp.vertrieb-plattform.de/edocbox/editor/servlet/documentViewer?pAction=load&documentid=${docId}`;
-                    pageData = await gmFetchJson(fallbackUrl, { withCredentials: true });
-                }
-            }
-
-            if (!pageData || !Array.isArray(pageData.pages)) {
-                throw new Error('Dokument-Daten konnten nicht geladen werden (Interception und Fallback fehlgeschlagen).');
-            }
-
-            // Schritt 2: Versuche, das Formular auszufüllen
-            await performAutofill(pageData, wibiid);
-
-        } catch (e) {
-            // Schritt 3: Fehlerbehandlung bei nicht aktivem Haushalt
-            if (e && e.isHaushaltNotActive) {
-                console.log("Haushalt ist nicht aktiv. Starte den Aktivierungsprozess...");
-                try {
-                    // Versuche, den Haushalt zu aktivieren
-                    await activateHaushalt(wibiid);
-                    // Wenn die Aktivierung erfolgreich war, versuche das Ausfüllen erneut
-                    console.log("Aktivierung erfolgreich. Starte Autofill erneut.");
-                    updateOverlay("Fülle Formular aus...");
-                    await performAutofill(pageData, wibiid);
-                } catch (activationError) {
-                    // Wenn die Aktivierung fehlschlägt, zeige eine Fehlermeldung
-                    removeOverlay();
-                    console.error('Autofill-Fehler nach fehlgeschlagener Aktivierung:', activationError);
-                    alert('Automatischer Ladevorgang der Kundendaten fehlgeschlagen:\n\n' + (activationError.message || activationError));
-                    return;
-                }
-            } else {
-                // Behandle alle anderen, unerwarteten Fehler
-                removeOverlay();
-                console.error('Autofill script error:', e);
-                alert('Ein unerwarteter Autofill-Fehler ist aufgetreten:\n\n' + (e && e.message ? e.message : String(e)));
-                return;
+            const timeoutPromise = new Promise((_, reject) => setTimeout(() => reject("Timeout"), 5000));
+            pageData = await Promise.race([documentJsonPromise, timeoutPromise]);
+        } catch (err) {
+            console.log("Interceptor timed out or failed, trying manual fetch...");
+            const docId = qs.get('documentid');
+            if (docId) {
+                const fallbackUrl = `https://bm.bp.vertrieb-plattform.de/edocbox/editor/servlet/documentViewer?pAction=load&documentid=${docId}`;
+                pageData = await gmFetchJson(fallbackUrl, { withCredentials: true });
             }
         }
 
-        // Wenn alles gut ging, schließe das Overlay
-        removeOverlay();
-        console.log("Autofill erfolgreich abgeschlossen.");
+        if (!pageData || !Array.isArray(pageData.pages)) {
+            removeOverlay();
+            alert('Kritischer Fehler: Die Struktur des Dokuments konnte nicht geladen werden. Autofill abgebrochen.');
+            return;
+        }
+
+        // Schritt 2: VERSUCH (Plan A) - Führe den normalen Autofill-Prozess aus.
+        try {
+            console.log("Autofill: Starte ersten Versuch (Plan A)...");
+            await performAutofill(pageData, wibiid);
+
+            // Wenn wir hier ankommen, war alles erfolgreich.
+            console.log("Autofill: Plan A war erfolgreich. Keine Aktivierung nötig.");
+            removeOverlay();
+            console.log("Autofill erfolgreich abgeschlossen.");
+
+        } catch (error) {
+            // Schritt 3: FEHLERBEHANDLUNG - Plan A ist fehlgeschlagen.
+            // Prüfen, ob es der erwartete Fehler für inaktive Haushalte ist.
+            if (error && error.isHaushaltNotActive) {
+                console.warn("Autofill: Plan A fehlgeschlagen. Grund: Haushalt nicht aktiv. Starte Plan B...");
+
+                // Schritt 4: RETTUNGSAKTION (Plan B) - Aktiviere den Haushalt.
+                try {
+                    await activateHaushalt(wibiid);
+
+                    // Schritt 5: ZWEITER VERSUCH - Führe Autofill erneut aus.
+                    console.log("Autofill: Aktivierung erfolgreich. Starte zweiten Autofill-Versuch.");
+                    updateOverlay("Befüllt Gesprächsnotiz...");
+                    await performAutofill(pageData, wibiid);
+
+                    // Wenn wir hier ankommen, war Plan B erfolgreich.
+                    removeOverlay();
+                    console.log("Autofill erfolgreich nach Aktivierung abgeschlossen.");
+
+                } catch (activationError) {
+                    // Die Aktivierung selbst ist fehlgeschlagen.
+                    removeOverlay();
+                    console.error('Autofill-Fehler: Die automatische Aktivierung ist fehlgeschlagen:', activationError);
+                    alert('Automatischer Ladevorgang der Kundendaten fehlgeschlagen:\n\n' + (activationError.message || activationError));
+                }
+
+            } else {
+                // Ein anderer, unerwarteter Fehler ist aufgetreten.
+                removeOverlay();
+                console.error('Unerwarteter Autofill-Fehler:', error);
+                alert('Ein unerwarteter Autofill-Fehler ist aufgetreten:\n\n' + (error && error.message ? error.message : String(error)));
+            }
+        }
     }
 
     // =================================================================================

--- a/pars-pro-toto-BM-Autofill-chrome-extension/manifest.json
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Beratungsmappen Autofill Pars Pro Toto",
-  "version": "1.0.1",
+  "version": "2.1.0",
   "description": "Dokumente Datenbank und BM Gesprächsnotiz Autofill als Browsererweiterung.",
   "icons": {
     "16": "icons/icon-16.png",


### PR DESCRIPTION
### Motivation
- Das Autofill soll zuerst normal versuchen, das Formular zu befüllen und nur bei einem spezifischen Fehler (`Haushalt nicht aktiv`) die Aktivierung anstoßen, um unnötige Aktivierungen zu vermeiden.
- Die Browserextension soll die gleiche Versionsnummer wie das Userscript haben, damit Releases/Updates konsistent sind.

### Description
- Anpassung der Orchestrierungslogik in `content/tecis-bm-gespraechsnotiz-autofill.js`: `run()` lädt nun immer zuerst die grundlegenden Dokument-Daten und führt einen ersten Autofill-Versuch (Plan A) aus; nur wenn dieser mit `isHaushaltNotActive` fehlschlägt wird `activateHaushalt()` ausgeführt und anschließend ein zweiter Autofill-Versuch (Plan B) gestartet.
- Verbesserte Fehler- und Overlay-Behandlung: bei fehlenden Dokument-Daten wird das Overlay entfernt und ein kritischer Alert gezeigt, bei Aktivierungsfehlern und sonstigen Fehlern werden aussagekräftige Log- und Alert-Meldungen erzeugt.
- Feinschliff an Log-Nachrichten und Overlay-Texten während der Aktivierung und des zweiten Befüllungsversuchs.
- Versions-Update in `manifest.json` von `1.0.1` auf `2.1.0` zur Angleichung an das Userscript.

### Testing
- Es wurden keine automatisierten Tests ausgeführt in diesem PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974de4cfdb4832daede49fc784eb32c)