### PR TITLE
Autofill: cache API fetches and add income-source checkbox mapping

### DIFF
--- a/pars-pro-toto-BM-Autofill-chrome-extension/manifest.json
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Beratungsmappen Autofill Pars Pro Toto",
-  "version": "1.0.1",
+  "version": "2.1.0",
   "description": "Dokumente Datenbank und BM Gesprächsnotiz Autofill als Browsererweiterung.",
   "icons": {
     "16": "icons/icon-16.png",


### PR DESCRIPTION
### Motivation
- Reduce redundant API calls during autofill and avoid fetching the same cluster endpoint multiple times. 
- Support checkbox mapping for income-source data that is returned as an array so the right checkboxes are marked automatically.

### Description
- Added new income-source checkbox tasks (fields like `FinanzenHH_Einkommen_Chbx_Gehalt`, `FinanzenHH_Einkommen_Chbx_Rente`, etc.) using the `needle` `clusterDto.herkuenfteEinnahmen` and a new `contains` flag. 
- Introduced a `fetchCache` to cache `gmFetchJson` results per URL and reused cached JSON for subsequent tasks. 
- Updated the task execution loop to resolve a `val` from either `staticValue` or fetched JSON and to interpret `contains` by checking `Array.isArray(rawVal) && rawVal.includes(t.contains)` before calling `window.setFieldByIdResolvedValue(pageData, t.field, val, t.position)`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974de4cfdb4832daede49fc784eb32c)