### PR TITLE
Fix affiliate-free export to remove affiliate script and <all_urls> permission

### DIFF
--- a/pars-pro-toto-BM-Autofill-chrome-extension/export-variants.mjs
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/export-variants.mjs
@@ -106,6 +106,13 @@ function buildVariant(baseManifest, variant) {
     manifest.content_scripts = manifest.content_scripts.filter(
       (script) => !script.js?.includes(AFFILIATE_SCRIPT),
     );
+    manifest.optional_host_permissions = (manifest.optional_host_permissions ?? []).filter(
+      (permission) => permission !== '<all_urls>',
+    );
+    if (manifest.optional_host_permissions.length === 0) {
+      delete manifest.optional_host_permissions;
+    }
+    rmSync(join(variantDir, AFFILIATE_SCRIPT), { force: true });
   }
 
   writeManifest(variantDir, manifest);


### PR DESCRIPTION
### Motivation
- Ensure the `without-affiliate` distribution does not ship the affiliate updater source or retain an unnecessary broad host permission, so the store build is not over-privileged.

### Description
- Updated `pars-pro-toto-BM-Autofill-chrome-extension/export-variants.mjs` to delete `content/affiliate-links.js` from the exported `without-affiliate` folder after copying files by calling `rmSync(join(variantDir, AFFILIATE_SCRIPT), { force: true })`.
- Strip `"<all_urls>"` from `optional_host_permissions` for the `without-affiliate` manifest by filtering `manifest.optional_host_permissions` and delete the `optional_host_permissions` property when it becomes empty.
- Kept the existing removal of the affiliate content-script registration in `manifest.content_scripts` so the runtime registration and physical source are both excluded for the store variant.

### Testing
- Ran `node export-variants.mjs` to build both variants and the script completed successfully.
- Verified the affiliate source was removed with `test ! -f dist/pars-pro-toto-bm-autofill-without-affiliate/content/affiliate-links.js` which succeeded.
- Verified the generated `without-affiliate` `manifest.json` has `optional_host_permissions` undefined (i.e. the `<all_urls>` entry was removed), which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c26420a918832dbf6cede1007e1d3c)