### PR TITLE
Refactor: shared core + userscript/extension adapters and build targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,19 +1,27 @@
 name: FTP Deploy
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+      - master
 
 jobs:
   ftp-deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: FTP-Deploy-Action
-      uses: SamKirkland/FTP-Deploy-Action@4.2.0
-      with:
-        server: ${{ secrets.FTP_SERVER }}
-        username: ${{ secrets.FTP_USERNAME }}
-        password: ${{ secrets.FTP_PASSWORD }}
-        server-dir: /html/mopoliti.de/Userscripts/
-        local-dir: ./
-        exclude: |
-          **/pars-pro-toto-BM-Autofill-chrome-extension/**
+      - uses: actions/checkout@v4
+
+      - name: Build shared userscript/extension targets
+        run: npm --prefix pars-pro-toto-BM-Autofill-chrome-extension run build:targets
+
+      - name: FTP-Deploy-Action
+        uses: SamKirkland/FTP-Deploy-Action@4.2.0
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          server-dir: /html/mopoliti.de/Userscripts/
+          local-dir: ./
+          exclude: |
+            **/pars-pro-toto-BM-Autofill-chrome-extension/**

--- a/pars-pro-toto-BM-Autofill-chrome-extension/build-targets.mjs
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/build-targets.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = resolve(dirname(__filename));
+const REPO_ROOT = resolve(ROOT, '..');
+const DIST_USERSCRIPTS = resolve(REPO_ROOT, 'dist/userscripts');
+const DIST_EXTENSION = resolve(REPO_ROOT, 'dist/extension/content');
+
+mkdirSync(DIST_USERSCRIPTS, { recursive: true });
+mkdirSync(DIST_EXTENSION, { recursive: true });
+
+function read(path) {
+  return readFileSync(path, 'utf8');
+}
+
+function extractUserscriptHeader(source) {
+  const match = source.match(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==\n?/);
+  return match ? match[0].trimEnd() + '\n\n' : '';
+}
+
+function stripUserscriptHeader(source) {
+  return source.replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==\n?\n?/, '');
+}
+
+function stripImports(source) {
+  return source.replace(/^import\s+.+?;\n/gm, '');
+}
+
+function stripExports(source) {
+  return source.replace(/^export\s+/gm, '');
+}
+
+function bundle({ adapterPath, corePaths, outputPath, includeHeader = false }) {
+  const adapterSourceRaw = read(adapterPath);
+  const header = includeHeader ? extractUserscriptHeader(adapterSourceRaw) : '';
+  const adapterSource = stripImports(stripUserscriptHeader(adapterSourceRaw)).trim();
+  const coreSource = corePaths.map((path) => stripExports(read(path)).trim()).join('\n\n');
+
+  const output = `${header}(function () {\n'use strict';\n\n${coreSource}\n\n${adapterSource}\n})();\n`;
+  writeFileSync(outputPath, output, 'utf8');
+}
+
+const bmCore = resolve(ROOT, 'src/core/tecis-bm-gespraechsnotiz-autofill.core.js');
+const dokumenteCore = resolve(ROOT, 'src/core/tecis-dokumente-datenbank.core.js');
+
+bundle({
+  adapterPath: resolve(ROOT, 'src/adapters/userscript/tecis-bm-gespraechsnotiz-autofill.entry.js'),
+  corePaths: [bmCore],
+  outputPath: resolve(DIST_USERSCRIPTS, 'tecis-bm-gespraechsnotiz-autofill.user.js'),
+  includeHeader: true,
+});
+
+bundle({
+  adapterPath: resolve(ROOT, 'src/adapters/userscript/tecis-dokumente-datenbank.entry.js'),
+  corePaths: [dokumenteCore],
+  outputPath: resolve(DIST_USERSCRIPTS, 'tecis-dokumente-datenbank.user.js'),
+  includeHeader: true,
+});
+
+bundle({
+  adapterPath: resolve(ROOT, 'src/adapters/extension/tecis-bm-gespraechsnotiz-autofill.entry.js'),
+  corePaths: [bmCore],
+  outputPath: resolve(DIST_EXTENSION, 'tecis-bm-gespraechsnotiz-autofill.js'),
+});
+
+bundle({
+  adapterPath: resolve(ROOT, 'src/adapters/extension/tecis-dokumente-datenbank.entry.js'),
+  corePaths: [dokumenteCore],
+  outputPath: resolve(DIST_EXTENSION, 'tecis-dokumente-datenbank.js'),
+});
+
+console.log('Built shared targets into dist/userscripts and dist/extension/content.');

--- a/pars-pro-toto-BM-Autofill-chrome-extension/package.json
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/package.json
@@ -2,6 +2,7 @@
   "name": "pars-pro-toto-bm-autofill-chrome-extension",
   "private": true,
   "scripts": {
+    "build:targets": "node build-targets.mjs",
     "export:variants": "node export-variants.mjs"
   }
 }

--- a/pars-pro-toto-BM-Autofill-chrome-extension/src/adapters/extension/tecis-bm-gespraechsnotiz-autofill.entry.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/src/adapters/extension/tecis-bm-gespraechsnotiz-autofill.entry.js
@@ -1,0 +1,88 @@
+import { initGespraechsnotizAutofillEditor, initGespraechsnotizAutofillList } from '../../core/tecis-bm-gespraechsnotiz-autofill.core.js';
+
+function fetchJson(url, { method = 'GET', headers = {}, body = null, withCredentials = true } = {}) {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage(
+      {
+        type: 'fetchJson',
+        url,
+        options: {
+          method,
+          headers,
+          body,
+          credentials: withCredentials ? 'include' : 'omit',
+        },
+      },
+      (response) => {
+        if (chrome.runtime.lastError) return reject(new Error(chrome.runtime.lastError.message));
+        if (!response) return reject(new Error('No response from background'));
+        if (response.error) return reject(new Error(response.error));
+        if (!response.ok) {
+          const err = new Error(`HTTP ${response.status} for ${url}`);
+          err.status = response.status;
+          err.data = response.data;
+          return reject(err);
+        }
+        resolve(response.data);
+      },
+    );
+  });
+}
+
+function installWindowOpenHook() {
+  const script = document.createElement('script');
+  script.src = chrome.runtime.getURL('content/page-window-open-hook.js');
+  script.async = false;
+  (document.head || document.documentElement).appendChild(script);
+  script.onload = () => script.remove();
+}
+
+function signalPageAutofillNextOpen() {
+  window.postMessage({ source: 'tecis-extension', type: 'set-autofill-next-open' }, '*');
+}
+
+function createDocumentJsonPromise() {
+  let resolvePromise;
+  const promise = new Promise((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  const handler = (event) => {
+    if (event.source !== window) return;
+    if (!event.data || event.data.source !== 'tecis-extension') return;
+    if (event.data.type !== 'document-json') return;
+    resolvePromise(event.data.payload);
+    window.removeEventListener('message', handler);
+  };
+
+  window.addEventListener('message', handler);
+
+  const script = document.createElement('script');
+  script.textContent = `
+    (function() {
+      const originalOpen = XMLHttpRequest.prototype.open;
+      XMLHttpRequest.prototype.open = function(method, url) {
+        if (typeof url === 'string' && url.includes('pAction=load')) {
+          this.addEventListener('load', function() {
+            try {
+              const json = JSON.parse(this.responseText);
+              if (json && (json.pages || json.formFields)) {
+                window.postMessage({ source: 'tecis-extension', type: 'document-json', payload: json }, '*');
+              }
+            } catch (e) {
+              console.error('Autofill: Failed to parse intercepted JSON', e);
+            }
+          });
+        }
+        return originalOpen.apply(this, arguments);
+      };
+    })();
+  `;
+  (document.head || document.documentElement).appendChild(script);
+  script.remove();
+
+  return promise;
+}
+
+initGespraechsnotizAutofillList({ installWindowOpenHook, signalPageAutofillNextOpen });
+initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromise });

--- a/pars-pro-toto-BM-Autofill-chrome-extension/src/adapters/extension/tecis-dokumente-datenbank.entry.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/src/adapters/extension/tecis-dokumente-datenbank.entry.js
@@ -1,0 +1,38 @@
+import { initDokumenteDatenbank } from '../../core/tecis-dokumente-datenbank.core.js';
+
+function fetchJson(url, { method = 'GET', headers = {}, body = null, withCredentials = true } = {}) {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage(
+      {
+        type: 'fetchJson',
+        url,
+        options: {
+          method,
+          headers,
+          body,
+          credentials: withCredentials ? 'include' : 'omit',
+        },
+      },
+      (response) => {
+        if (chrome.runtime.lastError) return reject(new Error(chrome.runtime.lastError.message));
+        if (!response) return reject(new Error('No response from background'));
+        if (response.error) return reject(new Error(response.error));
+        if (!response.ok) {
+          const err = new Error(`HTTP ${response.status} for ${url}`);
+          err.status = response.status;
+          err.data = response.data;
+          return reject(err);
+        }
+        resolve(response.data);
+      },
+    );
+  });
+}
+
+function addCss(cssText) {
+  const style = document.createElement('style');
+  style.textContent = cssText;
+  document.head.appendChild(style);
+}
+
+initDokumenteDatenbank({ fetchJson, addCss });

--- a/pars-pro-toto-BM-Autofill-chrome-extension/src/adapters/userscript/tecis-bm-gespraechsnotiz-autofill.entry.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/src/adapters/userscript/tecis-bm-gespraechsnotiz-autofill.entry.js
@@ -1,0 +1,82 @@
+// ==UserScript==
+// @name         tecis BM Gesprächsnotiz Autofill
+// @namespace    http://tampermonkey.net/
+// @version      2.1.0
+// @description  Befüllt die Gesprächsnotiz wenn ?autofill=true gesetzt ist und fügt einen Autofill button in der BM hinzu
+// @author       Malte Kretzschmar
+// @match        https://bm.bp.vertrieb-plattform.de/bm/*
+// @match        https://bm.bp.vertrieb-plattform.de/edocbox/editor/ui/?documentid=*
+// @run-at       document-start
+// @grant        GM_xmlhttpRequest
+// @grant        GM.xmlHttpRequest
+// @connect      bm.bp.vertrieb-plattform.de
+// @connect      startkonzept.bp.vertrieb-plattform.de
+// @connect      mopoliti.de
+// @icon         https://www.google.com/s2/favicons?sz=64&domain=tecis.de
+// ==/UserScript==
+
+import { initGespraechsnotizAutofillEditor, initGespraechsnotizAutofillList } from '../../core/tecis-bm-gespraechsnotiz-autofill.core.js';
+
+function fetchJson(url, { method = 'GET', headers = {}, body = null } = {}) {
+  const gmRequest = (typeof GM !== 'undefined' && GM.xmlHttpRequest) ? GM.xmlHttpRequest : GM_xmlhttpRequest;
+  return new Promise((resolve, reject) => {
+    gmRequest({
+      method,
+      url,
+      headers,
+      data: body,
+      onload: (response) => {
+        try {
+          resolve(JSON.parse(response.responseText));
+        } catch (error) {
+          reject(error);
+        }
+      },
+      onerror: reject,
+    });
+  });
+}
+
+function installWindowOpenHook({ appendParams, consumeAutofillNextOpen }) {
+  const pageWindow = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;
+  const originalOpen = pageWindow.open;
+  Object.defineProperty(pageWindow, 'open', {
+    configurable: true,
+    writable: true,
+    value(url, name, specs, replace) {
+      if (typeof url === 'string') {
+        url = appendParams(url, { forceAutofill: consumeAutofillNextOpen() });
+      }
+      return originalOpen.call(this, url, name, specs, replace);
+    },
+  });
+}
+
+function createDocumentJsonPromise() {
+  let resolvePromise;
+  const promise = new Promise((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  const originalOpen = XMLHttpRequest.prototype.open;
+  XMLHttpRequest.prototype.open = function (method, url) {
+    if (typeof url === 'string' && url.includes('pAction=load')) {
+      this.addEventListener('load', function () {
+        try {
+          const json = JSON.parse(this.responseText);
+          if (json && (json.pages || json.formFields)) {
+            resolvePromise(json);
+          }
+        } catch (error) {
+          console.error('Autofill: Failed to parse intercepted JSON', error);
+        }
+      });
+    }
+    return originalOpen.apply(this, arguments);
+  };
+
+  return promise;
+}
+
+initGespraechsnotizAutofillList({ installWindowOpenHook });
+initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromise });

--- a/pars-pro-toto-BM-Autofill-chrome-extension/src/adapters/userscript/tecis-dokumente-datenbank.entry.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/src/adapters/userscript/tecis-dokumente-datenbank.entry.js
@@ -1,0 +1,49 @@
+// ==UserScript==
+// @name         tecis Dokumente Datenbank
+// @namespace    http://tampermonkey.net/
+// @version      1.8.4
+// @description  Vorbefüllte PDFs und Anträge mit einem Click in die Beratungsmappe laden: HEK, hkk, Erhöhungen und Kampagnen
+// @author       Malte Kretzschmar
+// @match        https://bm.bp.vertrieb-plattform.de/bm/*
+// @grant        GM_xmlhttpRequest
+// @grant        GM.xmlHttpRequest
+// @grant        GM_addStyle
+// @connect      mopoliti.de
+// @connect      www.crm.vertrieb-plattform.de
+// @require      https://mopoliti.de/Userscripts/libraries/pdf-lib.js
+// @icon         https://www.google.com/s2/favicons?sz=64&domain=tecis.de
+// ==/UserScript==
+
+import { initDokumenteDatenbank } from '../../core/tecis-dokumente-datenbank.core.js';
+
+function fetchJson(url, { method = 'GET', headers = {}, body = null } = {}) {
+  const gmRequest = (typeof GM !== 'undefined' && GM.xmlHttpRequest) ? GM.xmlHttpRequest : GM_xmlhttpRequest;
+  return new Promise((resolve, reject) => {
+    gmRequest({
+      method,
+      url,
+      headers,
+      data: body,
+      onload: (response) => {
+        try {
+          resolve(JSON.parse(response.responseText));
+        } catch (error) {
+          reject(error);
+        }
+      },
+      onerror: reject,
+    });
+  });
+}
+
+function addCss(cssText) {
+  if (typeof GM_addStyle === 'function') {
+    GM_addStyle(cssText);
+    return;
+  }
+  const style = document.createElement('style');
+  style.textContent = cssText;
+  document.head.appendChild(style);
+}
+
+initDokumenteDatenbank({ fetchJson, addCss });

--- a/pars-pro-toto-BM-Autofill-chrome-extension/src/core/tecis-bm-gespraechsnotiz-autofill.core.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/src/core/tecis-bm-gespraechsnotiz-autofill.core.js
@@ -1,0 +1,973 @@
+// ===== Gesprächsnotiz: clone Bearbeiten with Autofill =====
+export function initGespraechsnotizAutofillList({ installWindowOpenHook, signalPageAutofillNextOpen = () => {} }) {
+    // Only run this block on the BM list page
+    if (!location.href.startsWith("https://bm.bp.vertrieb-plattform.de/bm/")) return;
+
+    // -------- URL param helpers --------
+    let addAutofillNextOpen = false; // one-shot flag for the next window.open()
+
+    function getCurrentWibiid() {
+        try { return new URL(location.href).searchParams.get("wibiid"); }
+        catch { return null; }
+    }
+
+    function isNormalUrl(u) {
+        return typeof u === "string" && !/^(?:javascript:|data:|blob:)/i.test(u);
+    }
+
+    function appendParams(u, { forceAutofill = false } = {}) {
+        if (!isNormalUrl(u)) return u;
+        let target;
+        try { target = new URL(u, location.href); }
+        catch { return u; }
+
+        const wibiid = getCurrentWibiid();
+        if (wibiid && !target.searchParams.has("wibiid")) {
+            target.searchParams.set("wibiid", wibiid);
+        }
+        if (forceAutofill) {
+            target.searchParams.set("autofill", "true");
+        }
+        return target.toString();
+    }
+
+    // -------- Intercept window.open in page context (covers PrimeFaces flows) --------
+    installWindowOpenHook({
+        appendParams,
+        consumeAutofillNextOpen: () => {
+            const forceAutofill = addAutofillNextOpen;
+            addAutofillNextOpen = false;
+            return forceAutofill;
+        },
+    });
+
+    // Also catch plain links that open in a new tab (Ctrl/Meta/middle click)
+    function handleLinkNewTab(ev) {
+        const a = ev.target && ev.target.closest && ev.target.closest("a[href]");
+        if (!a) return;
+
+        const willOpenNewTab =
+            a.target === "_blank" || ev.ctrlKey || ev.metaKey || ev.button === 1;
+
+        if (!willOpenNewTab) return;
+
+        // If this click originated from our Autofill button, set autofill for this navigation
+        if (ev.target && ev.target.closest && ev.target.closest(".autofill-button")) {
+            addAutofillNextOpen = true;
+        }
+
+        const href = a.getAttribute("href");
+        if (!href) return;
+
+        const newHref = appendParams(href, { forceAutofill: addAutofillNextOpen });
+        if (newHref !== href) a.setAttribute("href", newHref);
+
+        // one-shot
+        addAutofillNextOpen = false;
+    }
+    window.addEventListener("click", handleLinkNewTab, true);
+    window.addEventListener("auxclick", handleLinkNewTab, true);
+
+    // -------- DOM patcher: find Gesprächsnotiz rows & clone the button --------
+    function isGespraechsnotizRow(row) {
+        try {
+            const first = row.querySelector(".first, #page\\:center\\:contentForm\\:nbVorgList\\:0\\:j_idt376\\:1\\:dfirst");
+            return first && first.textContent.trim() === "Gesprächsnotiz";
+        } catch { return false; }
+    }
+
+    function enhanceRow(row) {
+        if (row.dataset.autofillAugmented === "1") return; // already done
+
+        // Find the Bearbeiten button (PrimeFaces uses this class in your snippet)
+        const editBtn = row.querySelector("button.edit-document-button");
+        if (!editBtn) return;
+
+        // Avoid doubling if an autofill twin already exists
+        if (row.querySelector(".autofill-button")) return;
+
+        // Clone it
+        const autofillBtn = editBtn.cloneNode(true);
+
+        // Make it visually/semantically distinct
+        autofillBtn.classList.add("autofill-button");
+        autofillBtn.title = "Bearbeiten (Autofill)";
+        // Update the label text in its span
+        const labelSpan = autofillBtn.querySelector(".ui-button-text, span.ui-button-text");
+        if (labelSpan) labelSpan.textContent = "Autofill";
+
+        // Make the id/name unique (optional; helps avoid duplicate ids)
+        if (autofillBtn.id) autofillBtn.id += "_autofill";
+        if (autofillBtn.name) autofillBtn.name += "_autofill";
+
+        // Add a pre-click hook that sets the one-shot autofill flag,
+        // then lets the original inline onclick (PrimeFaces.ab(...);return false;) run.
+        autofillBtn.addEventListener("click", function () {
+            addAutofillNextOpen = true; // ensure the *next* link uses autofill=true
+            signalPageAutofillNextOpen();
+            // Do not preventDefault: we want the original onclick to execute
+        }, { capture: true });
+
+        // Insert right after the original Bearbeiten button
+        editBtn.parentElement.insertBefore(autofillBtn, editBtn.nextSibling);
+
+        row.dataset.autofillAugmented = "1";
+    }
+
+    function scan() {
+        // Rows often look like: <div class="dokumentRow ..."> ... <div class="first">Gesprächsnotiz</div> ... <div class="third">[buttons]</div> ...
+        const rows = document.querySelectorAll("div.dokumentRow, div.bm_docRow1, div[id*='panelDokumente']");
+        rows.forEach(row => {
+            if (isGespraechsnotizRow(row)) enhanceRow(row);
+        });
+    }
+
+    // Initial + observe JSF/PrimeFaces ajax updates
+    const mo = new MutationObserver(() => scan());
+    mo.observe(document.documentElement, { subtree: true, childList: true });
+    // Run once when DOM is ready
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", scan);
+    } else {
+        scan();
+    }
+}
+
+// ===== BP Editor Autofill (wibiid) =====
+export function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromise }) {
+    // Only run this block on the editor UI
+    if (!location.href.startsWith("https://bm.bp.vertrieb-plattform.de/edocbox/editor/ui/")) return;
+
+    // ------- 0. DATA INTERCEPTION (Run immediately) -------
+    // We create a promise that resolves when the page loads its own document JSON
+    const documentJsonPromise = createDocumentJsonPromise();
+
+
+    // ------- Small utilities -------
+    const qs = new URLSearchParams(window.location.search);
+    const isAutoFill = (qs.get('autofill') || '').toLowerCase() === 'true';
+    if(!isAutoFill) return;
+
+    // ------- Overlay Helper -------
+    function updateOverlay(message = "Gesprächsnotiz wird vorausgefüllt") {
+        const overlayId = 'autofill-loading-overlay';
+        let div = document.getElementById(overlayId);
+
+        if (!div) {
+            div = document.createElement('div');
+            div.id = overlayId;
+            div.style.cssText = `
+            position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+            background: rgba(255, 255, 255, 0.75); z-index: 999999;
+            display: flex; justify-content: center; align-items: center;
+            flex-direction: column; font-family: sans-serif; text-align: center;
+        `;
+            const text = document.createElement('div');
+            text.className = 'autofill-overlay-text'; // Klasse für einfache Auswahl
+            text.style.cssText = "font-size: 24px; color: #333; margin-bottom: 20px; padding: 0 20px;";
+            div.appendChild(text);
+
+            const spinner = document.createElement('div');
+            spinner.style.cssText = "border: 5px solid #f3f3f3; border-top: 5px solid #3498db; border-radius: 50%; width: 40px; height: 40px; animation: spin 1s linear infinite;";
+            const style = document.createElement('style');
+            style.innerHTML = "@keyframes spin {0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); }}";
+            div.appendChild(style);
+            div.appendChild(spinner);
+
+            document.body.appendChild(div);
+        }
+
+        const textEl = div.querySelector('.autofill-overlay-text');
+        if (textEl) textEl.innerText = message;
+    }
+
+    function removeOverlay() {
+        const div = document.getElementById('autofill-loading-overlay');
+        if (div) div.remove();
+    }
+
+    const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+    function decodeBase64Url(b64) {
+        if (!b64) return '';
+        b64 = b64.replace(/-/g, '+').replace(/_/g, '/');
+        while (b64.length % 4) b64 += '=';
+        try {
+            return decodeURIComponent(Array.prototype.map.call(atob(b64), c =>
+                '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+            ).join(''));
+        } catch (e) {
+            try { return atob(b64); } catch { return ''; }
+        }
+    }
+
+    function gmFetchJson(url, { method = 'GET', headers = {}, body = null, withCredentials = true } = {}) {
+        return fetchJson(url, { method, headers, body, withCredentials })
+            .catch((err) => {
+                if (err.status === 500 && err.data && err.data.errorType === "HAUSHALT_NOT_ACTIVE") {
+                    const customErr = new Error("HAUSHALT_NOT_ACTIVE");
+                    customErr.isHaushaltNotActive = true;
+                    throw customErr;
+                }
+                throw err;
+            });
+    }
+
+    // --- NEU: Funktion zur Aktivierung des Haushalts im Startkonzept ---
+    async function activateHaushalt(haushaltId) {
+        const apiBase = 'https://startkonzept.bp.vertrieb-plattform.de/api';
+        updateOverlay('Haushalt ist nicht aktiv. Lade Daten aus dem Startkonzept...');
+
+        // Schritt 1: Kundennamen für die Erstellung der Beratung ermitteln
+        let kundenname = '';
+        try {
+            const konstellationUrl = `${apiBase}/haushalt-konstellation/${haushaltId}`;
+            const konstellationData = await gmFetchJson(konstellationUrl);
+            const vorstand = konstellationData?.haushaltsvorstand;
+            if (vorstand?.vorname && vorstand?.name) {
+                kundenname = `${vorstand.vorname} ${vorstand.name}`;
+                console.log(`Autofill: Kundenname für die Aktivierung gefunden: ${kundenname}`);
+            } else {
+                throw new Error("Kundenname konnte nicht aus der Haushalts-Konstellation ermittelt werden.");
+            }
+        } catch (err) {
+            console.error("Fehler bei der Ermittlung des Kundennamens:", err);
+            throw new Error("Aktivierung fehlgeschlagen: Kundenname konnte nicht abgerufen werden.");
+        }
+
+        // Schritt 2: Eine neue Beratung (Consultation) erstellen, um den Ladevorgang anzustoßen
+        try {
+            const consultationUrl = `${apiBase}/consultation`;
+            await gmFetchJson(consultationUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+                body: JSON.stringify({
+                    description: "",
+                    haushaltId: haushaltId,
+                    kundenname: kundenname
+                })
+            });
+            console.log("Autofill: Beratung erfolgreich erstellt, Ladevorgang gestartet.");
+        } catch (err) {
+            console.error("Fehler beim Erstellen der Beratung:", err);
+            throw new Error("Aktivierung fehlgeschlagen: Beratung konnte nicht gestartet werden.");
+        }
+
+        // Schritt 3: Den Lade-Status pollen, bis der Haushalt aktiv ist
+        const statusUrl = `${apiBase}/haushalt/${haushaltId}/loading-status`;
+        for (let i = 0; i < 30; i++) { // Timeout nach ca. 60 Sekunden
+            await sleep(2000); // 2 Sekunden zwischen den Prüfungen warten
+            try {
+                const statusData = await gmFetchJson(statusUrl);
+                const statusNote = statusData.note || '';
+                console.log(`Autofill: Lade-Status: "${statusNote}"`);
+                updateOverlay(`Lade Daten... (${statusNote})`);
+
+                if (statusNote.includes("Haushalt ist geladen und aktiv")) {
+                    console.log("Autofill: Haushalt erfolgreich aktiviert!");
+                    updateOverlay("Daten geladen, fülle Formular aus...");
+                    await sleep(500); // Kurze Pause, bevor es weitergeht
+                    return; // Erfolg!
+                }
+            } catch (err) {
+                console.log("Warnung: Fehler beim Abrufen des Lade-Status (Versuch wird fortgesetzt):", err);
+            }
+        }
+
+        throw new Error("Aktivierung fehlgeschlagen: Zeitüberschreitung beim Warten auf die Haushalts-Aktivierung.");
+    }
+
+    // ---- JSON path helper (e.g. "clusterDto.liquidesVermoegen" or "arr[0].x") ----
+    function getByPath(obj, path) {
+        if (!path) return undefined;
+        const norm = path.replace(/\[(\d+)\]/g, '.$1').replace(/^\./, '');
+        return norm.split('.').reduce((acc, k) => (acc == null ? undefined : acc[k]), obj);
+    }
+
+    // 3) EED Autofill Helper (mit Auto-Scroll & resolvierter URL/Needle)
+    (function(){
+        function asArray(x){
+            if (Array.isArray(x)) return x;
+            if (!x) return [];
+            if (typeof x === 'object') return Object.values(x);
+            return [];
+        }
+
+        function getAllPages(allJson){
+            const pages = asArray(allJson && allJson.pages);
+            if (!pages.length) throw new Error('allJson.pages[] missing or empty');
+            return pages;
+        }
+
+        function translatFacts(apiValue){
+            switch (apiValue){
+                //Anzahl an Geschäften
+                case 'Keine': return '0';
+                case 'Anzahl_1_5': return '1';
+                case 'Anzahl_6_10': return '2';
+                case 'Anzahl_mehr': return '3';
+                //gegenwert
+                case "Wert_1_3000": return '1';
+                case "Wert_3001_5000": return '2';
+                case "Wert_5001_10000": return '3';
+                case "Wert_mehr": return '4';
+            }
+        }
+        // ---------------------------------------------------------------------------
+
+        function findJsonField(allJson, fieldId, valueForRadio, position){
+            const pages = getAllPages(allJson);
+            let candidates = [];
+
+            for (const page of pages){
+                for (const f of asArray(page.fields)){
+                    if (!f || f.id !== fieldId) continue;
+
+                    // Logic for specific radio values (legacy support)
+                    const type = (f.t || '').toLowerCase();
+                    if (type === 'radio' && valueForRadio != null && !position){
+                        if (String(f.valchecked) === String(translatFacts(valueForRadio))) return {page, field: f};
+                    }
+                    candidates.push({page, field: f});
+                }
+            }
+            if (!candidates.length) throw new Error(`Field id "${fieldId}" not found in any page`);
+
+            // Check for spatial requirements
+            if (position === 'left') {
+                candidates.sort((a, b) => (a.field.x || 0) - (b.field.x || 0));
+                return candidates[0];
+            }
+            if (position === 'right') {
+                candidates.sort((a, b) => (b.field.x || 0) - (a.field.x || 0));
+                return candidates[0];
+            }
+
+            // Default (first found)
+            return candidates[0];
+        }
+
+        function getEedPageByNumber(pageNumber) {
+            const pages = Array.from(document.querySelectorAll('eed-page'));
+            for (const p of pages) {
+                const num = p.querySelector('eed-page-number .page-number');
+                if (num && num.textContent.trim() === String(pageNumber)) return p;
+            }
+            return null;
+        }
+
+        function getScrollContainer(){
+            const anyPage = document.querySelector('eed-page');
+            let el = anyPage ? anyPage.parentElement : null;
+            while (el){
+                const style = getComputedStyle(el);
+                if ((style.overflowY === 'auto' || style.overflowY === 'scroll') && el.scrollHeight > el.clientHeight) {
+                    return el;
+                }
+                el = el.parentElement;
+            }
+            return document.scrollingElement || document.documentElement || document.body;
+        }
+
+        function median(arr){ const s=[...arr].sort((a,b)=>a-b); const m=Math.floor(s.length/2); return s.length? (s.length%2? s[m] : (s[m-1]+s[m])/2) : 800; }
+
+        function renderedPagesInfo(){
+            const items = [];
+            document.querySelectorAll('eed-page').forEach(p=>{
+                const numTxt = p.querySelector('eed-page-number .page-number')?.textContent?.trim();
+                if (!numTxt) return;
+                const num = Number(numTxt);
+                const rect = p.getBoundingClientRect();
+                items.push({num, rect, el: p});
+            });
+            items.sort((a,b)=>a.rect.top - b.rect.top);
+            const nums = items.map(i=>i.num);
+            return {
+                items,
+                nums,
+                min: nums.length ? Math.min(...nums) : null,
+                max: nums.length ? Math.max(...nums) : null,
+                medianHeight: items.length ? median(items.map(i=>i.rect.height)) : 800
+            };
+        }
+
+        function getVirtualScroller() {
+            const el = document.querySelector('cdk-virtual-scroll-viewport');
+            if (!el || !el.__ngContext__) return null;
+            for (let i = 0; i < 30; i++) {
+                const item = el.__ngContext__[i];
+                if (item && typeof item === 'object' && typeof item.scrollToIndex === 'function') {
+                    return item;
+                }
+            }
+            return null;
+        }
+
+        async function revealPage(pageNumber, maxSteps=120){
+            let el = getEedPageByNumber(pageNumber);
+            if (el) return el;
+
+            const viewport = getVirtualScroller();
+            if (viewport) {
+                viewport.scrollToIndex(pageNumber - 1);
+                await sleep(150);
+                el = getEedPageByNumber(pageNumber);
+                if (el) return el;
+            }
+
+            const scroller = getScrollContainer();
+            for (let step=0; step<maxSteps; step++){
+                const info = renderedPagesInfo();
+                if (!info.items.length){
+                    scroller.scrollBy({top: 400, left: 0, behavior: 'auto'});
+                    await sleep(30);
+                    el = getEedPageByNumber(pageNumber);
+                    if (el) return el;
+                    continue;
+                }
+                el = getEedPageByNumber(pageNumber);
+                if (el) return el;
+
+                const {min, max, medianHeight} = info;
+                let dir = 0;
+                if (min != null && max != null) {
+                    if (pageNumber > max) dir = +1;
+                    else if (pageNumber < min) dir = -1;
+                    else dir = 0;
+                }
+                const delta = (dir === 0) ? (medianHeight * 0.6) : (dir * medianHeight * 0.95);
+                scroller.scrollBy({top: delta, behavior: 'auto'});
+                await sleep(70);
+            }
+            throw new Error(`Could not reveal eed-page ${pageNumber} by scrolling`);
+        }
+
+        function parsePx(v){
+            return typeof v === 'string' ? parseFloat(v.replace('px','')) : (v || 0);
+        }
+
+        function getPageScale(pageEl, jsonPageWidth) {
+            const pageBox = pageEl.querySelector('.page');
+            if (!pageBox) throw new Error('No .page element found inside eed-page');
+            const cssW = parsePx(pageBox.style.width) || pageBox.getBoundingClientRect().width;
+            return cssW / (jsonPageWidth || 1200);
+        }
+
+        function computeTargetRect(fieldEntry, scale){
+            return {
+                left: (fieldEntry.x || 0) * scale,
+                top:  (fieldEntry.y || 0) * scale,
+                w:    (fieldEntry.w || 0) * scale,
+                h:    (fieldEntry.h || 0) * scale
+            };
+        }
+
+        function coordsMatch(el, target, tol=3.8){
+            const left = parsePx(el.style.left);
+            const top  = parsePx(el.style.top);
+            const w    = parsePx(el.style.width);
+            const h    = parsePx(el.style.height);
+            return Math.abs(left-target.left)<=tol && Math.abs(top-target.top)<=tol &&
+                Math.abs(w-target.w)<=tol   && Math.abs(h-target.h)<=tol;
+        }
+
+        function getFormfields(pageEl){
+            return Array.from(pageEl.querySelectorAll('.formfield'));
+        }
+
+        async function findDomNodeForField(pageJson, fieldEntry) {
+            const pageEl = await revealPage(pageJson.page);
+            pageEl.scrollIntoView({block: 'center', behavior: 'auto'});
+
+            // We use MutationObserver to wait for the field to appear instead of a fixed polling loop.
+            return new Promise((resolve, reject) => {
+                const tryFind = () => {
+                    try {
+                        const scale = getPageScale(pageEl, pageJson.width);
+                        const target = computeTargetRect(fieldEntry, scale);
+                        const matches = getFormfields(pageEl).filter(ff => coordsMatch(ff, target));
+                        if (matches.length) return matches[0];
+                    } catch (e) {
+                        // Page or scale might not be ready yet
+                    }
+                    return null;
+                };
+
+                // 1. Immediate Check
+                const found = tryFind();
+                if (found) {
+                    resolve({node: found, pageEl});
+                    return;
+                }
+
+                // 2. Change Detection
+                const observer = new MutationObserver(() => {
+                    const node = tryFind();
+                    if (node) {
+                        observer.disconnect();
+                        resolve({node, pageEl});
+                    }
+                });
+
+                observer.observe(pageEl, { childList: true, subtree: true, attributes: true });
+
+                // 3. Timeout fallback (.5 seconds)
+                setTimeout(() => {
+                    observer.disconnect();
+                    reject(new Error(`Formfield at specified coordinates not found on page ${pageJson.page} (Timeout)`));
+                }, 500);
+            });
+        }
+
+        async function getActionElement(wrapperEl){
+            let input = wrapperEl.querySelector('.frame input.input');
+            if (input) return {kind:'text', el: input};
+
+            const mat = wrapperEl.querySelector('mat-checkbox');
+            if (mat) {
+                const isRadioStyle = mat.classList.contains('radio');
+                const inp = mat.querySelector('input[type="checkbox"]');
+                return {kind: isRadioStyle ? 'radio' : 'checkbox', el: mat, inp};
+            }
+            input = wrapperEl.querySelector('input');
+            if (input) return {kind: input.type==='checkbox' ? 'checkbox' : 'text', el: input};
+            throw new Error('No actionable input element found inside .formfield');
+        }
+
+        function setNativeInputValue(input, value){
+            const proto = Object.getPrototypeOf(input) || HTMLInputElement.prototype;
+            const desc  = Object.getOwnPropertyDescriptor(proto, 'value') ||
+                Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+            if (desc && desc.set) desc.set.call(input, value);
+            else input.value = value;
+        }
+
+        function clickMaterial(matEl){
+            const input = matEl.querySelector('input[type="checkbox"]');
+            if (input) { input.click(); return; }
+            const label = matEl.querySelector('label');
+            if (label) { label.click(); return; }
+            const inner = matEl.querySelector('.mat-checkbox-inner-container');
+            if (inner) { inner.click(); return; }
+            matEl.click();
+        }
+
+        async function withTemporarilyEnabled(inputEl, fn){
+            const wasDisabled = !!inputEl.disabled;
+            if (wasDisabled) inputEl.disabled = false;
+            try { return await fn(); }
+            finally { if (wasDisabled) inputEl.disabled = true; }
+        }
+
+        async function setText(wrapperEl, value){
+            const {el: input} = await getActionElement(wrapperEl);
+            await withTemporarilyEnabled(input, async () => {
+                input.focus();
+                setNativeInputValue(input, value == null ? '' : String(value));
+                input.dispatchEvent(new Event('input',  {bubbles:true}));
+                input.dispatchEvent(new Event('change', {bubbles:true}));
+                input.dispatchEvent(new Event('blur',   {bubbles:true}));
+            });
+        }
+
+        async function setCheckbox(wrapperEl, want){
+            const action = await getActionElement(wrapperEl);
+            if (action.kind !== 'checkbox') throw new Error('Target is not a checkbox');
+            const getState = () => {
+                if (action.inp) {
+                    const aria = action.inp.getAttribute('aria-checked');
+                    if (aria === 'true' || aria === 'false') return aria === 'true';
+                    return !!action.inp.checked;
+                }
+                const aria = wrapperEl.querySelector('input[type="checkbox"]')?.getAttribute('aria-checked');
+                if (aria === 'true' || aria === 'false') return aria === 'true';
+                const cb = wrapperEl.querySelector('input[type="checkbox"]');
+                return !!(cb && cb.checked);
+            };
+            want = !!want;
+            for (let i=0; i<2 && getState() !== want; i++){
+                clickMaterial(action.el || wrapperEl);
+                await sleep(14);
+            }
+            const inp = action.inp || wrapperEl.querySelector('input[type="checkbox"]');
+            if (inp){
+                inp.dispatchEvent(new Event('change', {bubbles:true}));
+                inp.dispatchEvent(new Event('blur',   {bubbles:true}));
+            }
+        }
+
+        async function setRadio(wrapperEl){
+            const action = await getActionElement(wrapperEl);
+            if (action.kind !== 'radio') throw new Error('Target is not a radio');
+            clickMaterial(action.el || wrapperEl);
+            const inp = action.inp || wrapperEl.querySelector('input[type="checkbox"]');
+            if (inp){
+                inp.dispatchEvent(new Event('change', {bubbles:true}));
+                inp.dispatchEvent(new Event('blur',   {bubbles:true}));
+            }
+            await sleep(10);
+        }
+
+        // Updated signature to accept position
+        window.setFieldByIdResolvedValue = async function(allJson, fieldId, value, position){
+            const {page, field} = findJsonField(allJson, fieldId, value, position);
+            const {node} = await findDomNodeForField(page, field);
+            const type = (field.t || '').toLowerCase();
+            if (type === 'text')     return setText(node, value);
+            if (type === 'checkbox') return setCheckbox(node, !!value);
+            if (type === 'radio')    return setRadio(node);
+            throw new Error(`Unsupported field type "${field.t}" for id "${fieldId}"`);
+        };
+
+        window.setFieldById = async function(allJson, fieldId, url, needle, position){
+            const json = await gmFetchJson(url, { withCredentials: true });
+            const value = getByPath(json, needle);
+            return window.setFieldByIdResolvedValue(allJson, fieldId, value, position);
+        };
+
+        console.log('%c[EED helper] Ready: setFieldById(allJson, fieldId, url, needle, position)','color:#0a0;font-weight:bold;');
+    })();
+
+    if (!isAutoFill) return;
+
+    // =================================================================================
+    // RUN Autofill
+    // =================================================================================
+
+    /**
+     * Führt den eigentlichen Ausfüllprozess aus, nachdem alle Vorbedingungen erfüllt sind.
+     */
+    async function performAutofill(pageData, wibiid) {
+        // 4) Mappings
+        const apiBase = 'https://startkonzept.bp.vertrieb-plattform.de/api';
+
+        console.log(`${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvKenntnisseUndErfahrungen&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`);
+        const tasks = [
+            // --- EXISTING FIELDS ---
+            {
+                field: 'Angaben_zum_Gespraech_Beruf1',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=KundeStammdaten&clusterId=0140d6ba-3c7d-4ee3-a918-fa30af996043`,
+                needle: 'clusterDto.beruf'
+            },
+            {
+                field: 'Profilierung_Kenntnisse_Chbx_Geldmarktfonds',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvKenntnisseUndErfahrungen&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.kunde.geldmarktfonds'
+            },
+            {
+                field: 'Profilierung_Kenntnisse_Chbx_Rentenfonds',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvKenntnisseUndErfahrungen&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.kunde.rentenfonds'
+            },
+            {
+                field: 'Profilierung_Kenntnisse_Chbx_Aktienfonds',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvKenntnisseUndErfahrungen&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.kunde.aktienfonds'
+            },
+            {
+                field: 'Profilierung_Kenntnisse_Chbx_Immofonds',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvKenntnisseUndErfahrungen&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.kunde.immobilienfonds'
+            },
+            {
+                field: 'Profilierung_Kenntnisse_Chbx_GemischteFonds',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvKenntnisseUndErfahrungen&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.kunde.gemischtefonds'
+            },
+            {
+                field: 'Profilierung_Kenntnisse_Chbx_Hedgefonds',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvKenntnisseUndErfahrungen&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.kunde.hedgefonds'
+            },
+            {
+                field: 'Profilierung_Kenntnisse_Chbx_RVoderLV',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvKenntnisseUndErfahrungen&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.kunde.versicherungen'
+            },
+            {
+                field: 'Profilierung_Kenntnisse_Chbx_Keine',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvKenntnisseUndErfahrungen&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.kunde.keine'
+            },
+            {
+                field: 'Profilierung_Kenntnisse_Radio_AnzGesch',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvKenntnisseUndErfahrungen&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.kunde.transaktionenAnzahl',
+                value: 1,
+            },
+            {
+                field: 'Profilierung_Kenntnisse_Radio_TransWert',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvKenntnisseUndErfahrungen&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.kunde.transaktionenWert',
+                value: 1,
+            },
+            {
+                field: 'Nachhaltigkeit_Beruecksichtigung',
+                staticValue: true,
+                position: 'right'
+            },
+            {
+                field: 'FinanzenHH_Einkommen_Monat',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvLaufendeEinnahmenUndAusgaben&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.monatlicheNettoeinnahmen',
+            },
+            {
+                field: 'FinanzenHH_Ausgaben_Monat',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvLaufendeEinnahmenUndAusgaben&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.monatlicheAusgaben',
+            },
+            // --- EINKOMMENS HERKUNFT CHECKBOXEN ---
+            {
+                field: 'FinanzenHH_Einkommen_Chbx_Gehalt',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvLaufendeEinnahmenUndAusgaben&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.herkuenfteEinnahmen',
+                contains: 'Gehalt'
+            },
+            {
+                field: 'FinanzenHH_Einkommen_Chbx_selbststTaetigk',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvLaufendeEinnahmenUndAusgaben&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.herkuenfteEinnahmen',
+                contains: 'SelbststaendigeTaetigkeit'
+            },
+            {
+                field: 'FinanzenHH_Einkommen_Chbx_Rente',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvLaufendeEinnahmenUndAusgaben&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.herkuenfteEinnahmen',
+                contains: 'Rente'
+            },
+            {
+                field: 'FinanzenHH_Einkommen_Chbx_Miete',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvLaufendeEinnahmenUndAusgaben&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.herkuenfteEinnahmen',
+                contains: 'Miete'
+            },
+            {
+                field: 'FinanzenHH_Einkommen_Chbx_Kapital',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvLaufendeEinnahmenUndAusgaben&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.herkuenfteEinnahmen',
+                contains: 'Kapital'
+            },
+            {
+                field: 'FinanzenHH_Einkommen_Chbx_Sonstiges',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvLaufendeEinnahmenUndAusgaben&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.herkuenfteEinnahmen',
+                contains: 'Sonstiges'
+            },
+            {
+                field: 'FinanzenHH_Ueberschuss_Monat',
+                skip: true
+            },
+            {
+                field: 'FinanzenHH_Vermoegen_Liquides',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvVermoegenUndVerbindlichkeiten&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.liquidesVermoegen'
+            },
+            {
+                field: 'FinanzenHH_Vermoegen_Immo',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvVermoegenUndVerbindlichkeiten&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.immobilienVermoegen'
+            },
+            {
+                field: 'FinanzenHH_Vermoegen_Kapitalanlagen',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvVermoegenUndVerbindlichkeiten&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.kapitalanlagenVermoegen'
+            },
+            {
+                field: 'FinanzenHH_Verbindlichkeiten',
+                url: `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvVermoegenUndVerbindlichkeiten&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`,
+                needle: 'clusterDto.verbindlichkeiten'
+            },
+            {
+                field: 'FinanzenHH_Aenderungen_Radio',
+                staticValue: true,
+                position: 'right'
+            },
+            {
+                field: 'pep',
+                staticValue: true,
+                position: 'left'
+            },
+        ];
+
+        // --- LOGGING NON-AUTOFILLED FIELDS ---
+        const allFieldIds = [];
+        (pageData.pages || []).forEach(p => {
+            const fields = Array.isArray(p.fields) ? p.fields : Object.values(p.fields || {});
+            fields.forEach(f => { if (f && f.id) allFieldIds.push(f.id); });
+        });
+
+        const filledIds = new Set(tasks.map(t => t.field));
+        const notFilled = allFieldIds.filter(id => !filledIds.has(id));
+
+        console.group("Fields NOT Autofilled");
+        console.log("Total fields found:", allFieldIds.length);
+        console.log("Total fields filled:", filledIds.size);
+        console.log("List of unfilled fields:", notFilled);
+        console.groupEnd();
+
+        // 5) gewünschte 1s-Verzögerung
+        await sleep(1000);
+
+        // 6) Execute mappings
+        // Cache für API-Abfragen, damit wir nicht 6x die gleiche URL abrufen
+        const fetchCache = {};
+
+        for (const t of tasks) {
+            try {
+                if (t.skip) continue;
+
+                let val;
+
+                // Fall A: Statischer Wert
+                if (t.staticValue !== undefined) {
+                    val = t.staticValue;
+                }
+                // Fall B: Wert aus API laden
+                else if (t.url) {
+                    // Caching nutzen oder neu laden
+                    if (!fetchCache[t.url]) {
+                        fetchCache[t.url] = await gmFetchJson(t.url, { withCredentials: true });
+                    }
+                    const json = fetchCache[t.url];
+                    const rawVal = getByPath(json, t.needle);
+
+                    // NEU: Wenn "contains" gesetzt ist, prüfen wir, ob der Wert im Array steckt
+                    if (t.contains) {
+                        val = Array.isArray(rawVal) && rawVal.includes(t.contains);
+                    } else {
+                        // Standard Verhalten (1-zu-1)
+                        val = rawVal;
+                    }
+                }
+
+                if (val !== undefined) {
+                    await window.setFieldByIdResolvedValue(pageData, t.field, val, t.position);
+                }
+            } catch (err) {
+                if (err.isHaushaltNotActive) throw err;
+                console.error(`Failed to set field "${t.field}":`, err);
+            }
+        }
+
+        // 7) Special Calculation: Ueberschuss
+        try {
+            const finUrl = `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=AvLaufendeEinnahmenUndAusgaben&clusterId=9c635702-2ea2-4190-942a-2cea750c46e1`;
+            const finJson = await gmFetchJson(finUrl, { withCredentials: true });
+            const inc = parseFloat(getByPath(finJson, 'clusterDto.monatlicheNettoeinnahmen')) || 0;
+            const exp = parseFloat(getByPath(finJson, 'clusterDto.monatlicheAusgaben')) || 0;
+            const diff = inc - exp;
+            await window.setFieldByIdResolvedValue(pageData, 'FinanzenHH_Ueberschuss_Monat', diff);
+            console.log(`Calculated Ueberschuss: ${inc} - ${exp} = ${diff}`);
+        } catch (calcErr) {
+            if (calcErr.isHaushaltNotActive) throw calcErr;
+            console.error("Calculation for FinanzenHH_Ueberschuss_Monat failed:", calcErr);
+        }
+
+        // 8) Signature Fields: Ort + Date
+        try {
+            const stammdatenUrl = `${apiBase}/haushalt/${encodeURIComponent(wibiid)}/clusters?clusterType=KundeStammdaten&clusterId=0140d6ba-3c7d-4ee3-a918-fa30af996043`;
+            const stammdatenJson = await gmFetchJson(stammdatenUrl, { withCredentials: true });
+            const city = getByPath(stammdatenJson, 'clusterDto.ort') || '';
+
+            const now = new Date();
+            const dateStr = now.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+            const signatureValue = city ? `${city}, ${dateStr}` : dateStr;
+
+            const sigFields = ['Unterschriften_Ort_Dat', 'Unterschriften_Ort_Dat-1-', 'Unterschriften_Ort_Dat-2-'];
+            for (const fId of sigFields) {
+                try {
+                    await window.setFieldByIdResolvedValue(pageData, fId, signatureValue);
+                } catch (e) {
+                    // ignore if field not found
+                }
+            }
+        } catch (sigErr) {
+            if (sigErr.isHaushaltNotActive) throw sigErr;
+            console.error("Signature location/date autofill failed:", sigErr);
+        }
+    }
+
+
+    /**
+     * Hauptfunktion, die den gesamten Autofill-Prozess orchestriert.
+     */
+    async function run() {
+        if (!isAutoFill) return;
+        updateOverlay("Starte Autofill...");
+
+        let pageData;
+        const wibiid = decodeBase64Url(qs.get('wibiid') || '').trim();
+
+        // Schritt 1: Lade die grundlegenden Dokument-Daten. Dies ist immer notwendig.
+        try {
+            const timeoutPromise = new Promise((_, reject) => setTimeout(() => reject("Timeout"), 5000));
+            pageData = await Promise.race([documentJsonPromise, timeoutPromise]);
+        } catch (err) {
+            console.log("Interceptor timed out or failed, trying manual fetch...");
+            const docId = qs.get('documentid');
+            if (docId) {
+                const fallbackUrl = `https://bm.bp.vertrieb-plattform.de/edocbox/editor/servlet/documentViewer?pAction=load&documentid=${docId}`;
+                pageData = await gmFetchJson(fallbackUrl, { withCredentials: true });
+            }
+        }
+
+        if (!pageData || !Array.isArray(pageData.pages)) {
+            removeOverlay();
+            alert('Kritischer Fehler: Die Struktur des Dokuments konnte nicht geladen werden. Autofill abgebrochen.');
+            return;
+        }
+
+        // Schritt 2: VERSUCH (Plan A) - Führe den normalen Autofill-Prozess aus.
+        try {
+            console.log("Autofill: Starte ersten Versuch (Plan A)...");
+            await performAutofill(pageData, wibiid);
+
+            // Wenn wir hier ankommen, war alles erfolgreich.
+            console.log("Autofill: Plan A war erfolgreich. Keine Aktivierung nötig.");
+            removeOverlay();
+            console.log("Autofill erfolgreich abgeschlossen.");
+
+        } catch (error) {
+            // Schritt 3: FEHLERBEHANDLUNG - Plan A ist fehlgeschlagen.
+            // Prüfen, ob es der erwartete Fehler für inaktive Haushalte ist.
+            if (error && error.isHaushaltNotActive) {
+                console.warn("Autofill: Plan A fehlgeschlagen. Grund: Haushalt nicht aktiv. Starte Plan B...");
+
+                // Schritt 4: RETTUNGSAKTION (Plan B) - Aktiviere den Haushalt.
+                try {
+                    await activateHaushalt(wibiid);
+
+                    // Schritt 5: ZWEITER VERSUCH - Führe Autofill erneut aus.
+                    console.log("Autofill: Aktivierung erfolgreich. Starte zweiten Autofill-Versuch.");
+                    updateOverlay("Befüllt Gesprächsnotiz...");
+                    await performAutofill(pageData, wibiid);
+
+                    // Wenn wir hier ankommen, war Plan B erfolgreich.
+                    removeOverlay();
+                    console.log("Autofill erfolgreich nach Aktivierung abgeschlossen.");
+
+                } catch (activationError) {
+                    // Die Aktivierung selbst ist fehlgeschlagen.
+                    removeOverlay();
+                    console.error('Autofill-Fehler: Die automatische Aktivierung ist fehlgeschlagen:', activationError);
+                    alert('Automatischer Ladevorgang der Kundendaten fehlgeschlagen:\n\n' + (activationError.message || activationError));
+                }
+
+            } else {
+                // Ein anderer, unerwarteter Fehler ist aufgetreten.
+                removeOverlay();
+                console.error('Unerwarteter Autofill-Fehler:', error);
+                alert('Ein unerwarteter Autofill-Fehler ist aufgetreten:\n\n' + (error && error.message ? error.message : String(error)));
+            }
+        }
+    }
+
+    // =================================================================================
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', run, { once: true });
+    } else {
+        run();
+    }
+
+}

--- a/pars-pro-toto-BM-Autofill-chrome-extension/src/core/tecis-dokumente-datenbank.core.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/src/core/tecis-dokumente-datenbank.core.js
@@ -1,0 +1,431 @@
+export async function initDokumenteDatenbank({ fetchJson, addCss, PDFLibRef = PDFLib }) {
+
+    try {
+        addCss(`
+        div.awd-content-fixed { top: 80px !important; }
+        div.awd-concept-title-buttons { height: 85px !important; }
+    `);
+    } catch (e){
+
+    }
+
+    const { PDFDocument } = PDFLibRef;
+
+    // --- ⬇️ EDIT THIS SECTION FOR CONCATENATION RULES ⬇️ ---
+    // This map defines reusable concatenation rules. The server can refer to these
+    // rules by their key (e.g., "concat_Name_Vorname").
+    const concatenationMap = {
+        // CORRECTED: Using a filter that checks for the primary address flag ("primaer": true)
+        "concat_Strasse_Hausnummer" : ["$.adressen[?(@.primaer==true)].strasseHausnummer.strasse", " ", "$.adressen[?(@.primaer==true)].strasseHausnummer.hausNr"],
+        "concat_PLZ_Ort" : ["$.adressen[?(@.primaer==true)].plzOrt.postleitzahl", " ", "$.adressen[?(@.primaer==true)].plzOrt.ort"],
+        "concat_Name_Vorname": ["$.nachname",  ", ",  "$.vorname"],
+        "concat_Vorname_Nachname": ["$.vorname",  " ",  "$.nachname"],
+    };
+    // --- ⬆️ END OF EDITABLE SECTION ⬆️ ---
+
+    function waitForHeaderMatch(selector, expectedText, timeout = 600000) {
+        return new Promise((resolve, reject) => {
+            const startTime = Date.now();
+            let intervalId;
+            const observer = new MutationObserver(() => check());
+
+            const cleanup = () => {
+                observer.disconnect();
+                if (intervalId) {
+                    clearInterval(intervalId);
+                }
+            };
+
+            const check = () => {
+                const header = document.querySelector(selector);
+                if (header && header.textContent.includes(expectedText)) {
+                    cleanup();
+                    resolve(header);
+                    return;
+                }
+                if (Date.now() - startTime > timeout) {
+                    cleanup();
+                    reject(new Error(`Header did not contain "${expectedText}" within timeout.`));
+                }
+            };
+
+            observer.observe(document.documentElement, {
+                childList: true,
+                subtree: true,
+                characterData: true
+            });
+            intervalId = setInterval(check, 1000);
+            check();
+        });
+    }
+
+    // Wait for the header that should contain "Eigene Vorgänge"
+    try {
+        await waitForHeaderMatch('#page\\:center\\:content > h1', 'Eigene Vorgänge');
+    } catch (error) {
+        console.warn(error.message);
+        return;
+    }
+
+    // --- Step A: Fetch available PDF templates from your server ---
+    const pdfTemplatesUrl = 'https://mopoliti.de/tecis/Store/get_pdf_templates.php';
+    let pdfTemplates = [];
+    try {
+        const data = await fetchJson(pdfTemplatesUrl);
+        if (data.status === 'success' && Array.isArray(data.templates)) {
+            pdfTemplates = data.templates;
+        } else {
+            throw new Error(data.message || 'Error retrieving PDF templates');
+        }
+    } catch (err) {
+        console.error('Failed to fetch PDF templates:', err);
+        return;
+    }
+
+    let customerID;
+    document.querySelectorAll('.navigation_item_double').forEach(el => {
+        const text = el.innerText.trim();
+        if (/^\(\d+\)$/.test(text)) { // matches something like "(147566674)"
+            customerID = text.slice(1, -1);
+        }
+    });
+    const beraterID = document.querySelector("#page\\:center\\:exitForm\\:beraterInfoLink").innerText.slice(-6,);
+
+    // --- Step B: Fetch live personal data from the CRM API ---
+    const personalDataUrl = 'https://www.crm.vertrieb-plattform.de/kundendetails-personalien/api/personalien/person/' + customerID + '?betreuerNr=' + beraterID;
+    let personalData = {};
+    try {
+        const personalDataJson = await fetchJson(personalDataUrl);
+        if (personalDataJson && Array.isArray(personalDataJson.resultData) && personalDataJson.resultData.length > 0) {
+            personalData = personalDataJson.resultData[0];
+        } else {
+            throw new Error('Invalid personal data format.');
+        }
+    } catch (err) {
+        console.error('Failed to fetch personal data:', err);
+        return;
+    }
+
+    // --- Locate the DOM element where the new buttons will be added ---
+    const titleButtons = document.querySelector('#page\\:center\\:contentForm\\:titleButtons');
+    if (!titleButtons) {
+        console.error('Could not find the titleButtons element.');
+        return;
+    }
+
+    // Create a container for our new PDF buttons
+    const container = document.createElement('span');
+    container.style.display = 'block';
+    titleButtons.appendChild(container);
+
+    // Helper: Create a button for each PDF template
+    pdfTemplates.forEach(template => {
+        const btn = document.createElement('button');
+        btn.id = `pdf-button-${template.id}`;
+        btn.className = 'ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only';
+        btn.style.marginRight = '5px';
+        btn.innerHTML = `<span class="ui-button-text ui-c">${template.button_name}</span>`;
+        container.appendChild(btn);
+
+        btn.addEventListener('click', async function(event) {
+            event.preventDefault();
+
+            // --- A helper to perform an action with retries ---
+            async function performAction(action, retries = 3) {
+                for (let attempt = 0; attempt < retries; attempt++) {
+                    try {
+                        await action();
+                        return true;
+                    } catch (error) {
+                        console.error(`Attempt ${attempt + 1} failed:`, error);
+                        if (attempt < retries - 1) {
+                            await new Promise(resolve => setTimeout(resolve, 500));
+                        } else {
+                            console.error("All retries failed.");
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            // --- Sequential UI interactions ---
+            async function sequentialExecution() {
+                const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+                // Step 1: Click the "add Vorgang" button
+                await performAction(async () => {
+                    document.querySelector("#page\\:center\\:contentForm\\:addVorgang > span").click();
+                    await wait(200);
+                });
+
+                // Step 2: Select the "Änderung/Erhöhung" menu item
+                await performAction(async () => {
+                    const menuItem = Array.from(document.querySelectorAll("span.ui-menuitem-text"))
+                        .find(el => el.textContent.trim() === "Änderung/Erhöhung");
+                    if (!menuItem) throw new Error('Menu item "Änderung/Erhöhung" not found.');
+                    menuItem.click();
+                    await wait(400);
+                });
+
+                // Step 3: Automatically handle the checkbox (simulate a click)
+                if(template.gespraechsnotiz_name == null) {
+                    await performAction(async () => {
+                        const chkboxSelector = "#dialogForm0\\:chkbxNoGespraechsnotiz > div.ui-chkbox-box.ui-widget.ui-corner-all.ui-state-default";
+                        const chkbox = document.querySelector(chkboxSelector);
+                        if (!chkbox) throw new Error("Checkbox element not found.");
+                        chkbox.click();
+                        await wait(100);
+                    });
+                }
+                else {
+                    // Tampermonkey userscript body (run-at document-idle or after page is up)
+                    (function() {
+                        // Helper: escape JSF colons in CSS selectors
+                        const esc = id => id.replace(/:/g, '\\:');
+
+                        // Wait for an element to become present + (optionally) visible
+                        function waitFor(sel, {visible=false, timeout=5000} = {}) {
+                            return new Promise((resolve, reject) => {
+                                const start = performance.now();
+                                const tm = setInterval(() => {
+                                    const el = document.querySelector(sel);
+                                    if (el && (!visible || getComputedStyle(el).display !== 'none')) {
+                                        clearInterval(tm); resolve(el);
+                                    } else if (performance.now() - start > timeout) {
+                                        clearInterval(tm); reject(new Error('Timeout waiting for ' + sel));
+                                    }
+                                }, 50);
+                            });
+                        }
+
+                        async function selectMenuItemByText({buttonId, menuId, labelText}) {
+                            // 1) open the menu
+                            const btn = await waitFor('#' + esc(buttonId), {visible:true});
+                            btn.click();
+
+                            // 2) wait until menu is visible
+                            const menu = await waitFor('#' + esc(menuId), {visible:true});
+
+                            // 3) find the <span class="ui-menuitem-text"> with the label
+                            const items = menu.querySelectorAll('li.ui-menuitem a.ui-menuitem-link .ui-menuitem-text');
+                            const targetSpan = Array.from(items).find(s => s.textContent.trim() === labelText);
+                            if (!targetSpan) throw new Error('Menu item not found: ' + labelText);
+
+                            // 4) click it (on the A or the span is fine)
+                            targetSpan.click();
+                        }
+
+                        // Example call: adapt the label to what you actually need
+                        selectMenuItemByText({
+                            buttonId: 'dialogForm0:gn_auswahl_button',
+                            menuId:   'dialogForm0:gn_menu',
+                            labelText: template.gespraechsnotiz_name // <- exact visible label
+                        }).catch(console.error);
+
+                    })();
+
+                }
+
+                // Step 4: Set the title field with the template name
+                await performAction(async () => {
+                    const titleInput = document.querySelector("#dialogForm0\\:bezeichnung_input");
+                    if (!titleInput) throw new Error("Title input element not found.");
+                    titleInput.value = template.name;
+                    await wait(100);
+                });
+
+                // Step 5: Fetch and process the PDF file upload
+                await performAction(async () => {
+                    const fileInput = document.querySelector("#dialogForm0\\:fileUpload_anschreibenantrag_input");
+                    if (!fileInput) throw new Error("File input element not found.");
+
+                    // *** NEW: Fetch the PDF file on demand ***
+                    let pdfData;
+                    try {
+                        pdfData = await fetchJson(template.pdf_url);
+                        if (pdfData.status !== 'success' || !pdfData.pdf) {
+                            throw new Error(pdfData.message || 'Error fetching PDF file');
+                        }
+                    } catch (err) {
+                        console.error('Error fetching PDF file:', err);
+                        return;
+                    }
+                    const pdfBase64 = pdfData.pdf;
+
+                    // Convert the stored Base64 PDF into a Blob
+                    function base64ToBlob(base64, contentType = 'application/pdf') {
+                        const byteCharacters = atob(base64);
+                        const byteNumbers = new Array(byteCharacters.length);
+                        for (let i = 0; i < byteCharacters.length; i++) {
+                            byteNumbers[i] = byteCharacters.charCodeAt(i);
+                        }
+                        const byteArray = new Uint8Array(byteNumbers);
+                        return new Blob([byteArray], { type: contentType });
+                    }
+                    let pdfBlob = base64ToBlob(pdfBase64, 'application/pdf');
+
+                    // Use PDFLib to fill in the PDF fields based on the template's field mappings
+                    try {
+                        const existingPdfBytes = await pdfBlob.arrayBuffer();
+                        const pdfDoc = await PDFDocument.load(existingPdfBytes);
+                        const form = pdfDoc.getForm();
+
+                        // Debug: Log all fields found in the PDF
+                        const fields = form.getFields();
+                        console.log("Found PDF fields:");
+                        fields.forEach(field => console.log(`- ${field.getName()}`));
+
+                        // Use the field_mappings from the template
+                        const mappings = template.field_mappings || {};
+                        for (const [pdfFieldName, dataKey] of Object.entries(mappings)) {
+                            try {
+                                let finalValue;
+
+                                // First, check if the dataKey from the server is a key in our local concat map.
+                                if (concatenationMap.hasOwnProperty(dataKey)) {
+                                    // It is! Perform the concatenation.
+                                    const ruleParts = concatenationMap[dataKey];
+                                    const resolvedParts = ruleParts.map(part => {
+                                        if (typeof part === 'string' && part.startsWith('$')) {
+                                            return resolveJsonPath(personalData, part) || '';
+                                        }
+                                        return part; // It's a literal string
+                                    });
+                                    finalValue = resolvedParts.join('');
+                                } else {
+                                    // It's not a concat rule, so treat it as a normal data path.
+                                    finalValue = resolveJsonPath(personalData, dataKey) || "";
+                                }
+
+                                const textField = form.getTextField(pdfFieldName);
+                                textField.setText(String(finalValue));
+
+                            } catch (e) {
+                                console.warn(`Field "${pdfFieldName}" with rule "${dataKey}" could not be set.`, e);
+                            }
+                        }
+
+                        // Save the filled PDF and update pdfBlob
+                        const newPdfBytes = await pdfDoc.save();
+                        pdfBlob = new Blob([newPdfBytes], { type: 'application/pdf' });
+                        console.log("PDF fields have been filled.");
+                    } catch (err) {
+                        console.warn("PDFLib processing failed. Uploading original PDF.", err);
+                    }
+
+                    // Create a File object from the Blob and attach it to the file input
+                    const file = new File([pdfBlob], "Antrag.pdf", { type: pdfBlob.type });
+                    const dataTransfer = new DataTransfer();
+                    dataTransfer.items.add(file);
+                    fileInput.files = dataTransfer.files;
+                    fileInput.dispatchEvent(new Event("change"));
+                    await wait(200);
+                });
+            }
+
+            sequentialExecution().catch(console.error);
+        });
+    });
+
+    // --- Enhanced JSONPath Resolver ---
+    // This helper tokenizes the JSONPath string (splitting on dots not within brackets)
+    // and supports filter expressions like: [?( @.prop==value )]
+    function tokenizePath(path) {
+        // Remove leading "$" and optional dot.
+        if (path.startsWith('$')) {
+            path = path.substring(1);
+        }
+        if (path.startsWith('.')) {
+            path = path.substring(1);
+        }
+        const tokens = [];
+        let current = "";
+        let inBracket = false;
+        let bracketCount = 0;
+        for (let char of path) {
+            if (char === '[') {
+                inBracket = true;
+                bracketCount++;
+                current += char;
+            } else if (char === ']') {
+                current += char;
+                bracketCount--;
+                if (bracketCount === 0) {
+                    inBracket = false;
+                }
+            } else if (char === '.' && !inBracket) {
+                tokens.push(current);
+                current = "";
+            } else {
+                current += char;
+            }
+        }
+        if (current) {
+            tokens.push(current);
+        }
+        return tokens;
+    }
+
+    // The new resolveJsonPath now supports filter expressions that include nested dot notation.
+    function resolveJsonPath(obj, path) {
+        if (!path) return undefined;
+        // If the path does not start with '$', assume it's a direct property name.
+        if (!path.startsWith('$')) {
+            return obj[path];
+        }
+        const tokens = tokenizePath(path);
+        let current = obj;
+        for (let token of tokens) {
+            if (token === "") continue;
+
+            // Check for filter expression of the form: property[?(@.prop operator value)]
+            const filterMatch = token.match(/^(.*?)\[\?\(@\.(.*?)\s*(==|!=|>|>=|<|<=)\s*(.*?)\)\]$/);
+            if (filterMatch) {
+                const prop = filterMatch[1];
+                const filterProp = filterMatch[2];
+                const operator = filterMatch[3];
+                let compValue = filterMatch[4];
+                // Remove any surrounding quotes from the comparison value.
+                compValue = compValue.replace(/^['"]|['"]$/g, '');
+                if (compValue === 'true') compValue = true; // Handle boolean true
+                if (compValue === 'false') compValue = false; // Handle boolean false
+
+                current = current[prop];
+                if (!Array.isArray(current)) return undefined;
+                const filtered = current.filter(item => {
+                    const left = item[filterProp];
+                    switch (operator) {
+                        case '==': return left == compValue;
+                        case '!=': return left != compValue;
+                        case '>':  return left > compValue;
+                        case '>=': return left >= compValue;
+                        case '<':  return left < compValue;
+                        case '<=': return left <= compValue;
+                        default: return false;
+                    }
+                });
+                if (filtered.length === 0) return undefined;
+                current = (filtered.length === 1) ? filtered[0] : filtered;
+                continue;
+            }
+
+            // Check for array index token e.g., "adressen[0]"
+            const arrayMatch = token.match(/^(.*?)\[(\d+)\]$/);
+            if (arrayMatch) {
+                const prop = arrayMatch[1];
+                const index = parseInt(arrayMatch[2], 10);
+                current = current[prop];
+                if (!Array.isArray(current)) return undefined;
+                current = current[index];
+                continue;
+            }
+
+            // Regular property access.
+            current = current[token];
+            if (current === undefined) return undefined;
+        }
+        return current;
+    }
+
+
+}


### PR DESCRIPTION
### Motivation
- Remove duplicate maintenance of two full script copies by extracting pure logic into shared core modules and keeping only thin runtime-specific adapters.
- Provide a repeatable build that produces both userscript and extension bundles from the same source so edits happen in one place.
- Ensure the CI/deploy only runs on primary branches and produces the generated artifacts before upload.

### Description
- Introduced shared core modules `src/core/tecis-bm-gespraechsnotiz-autofill.core.js` and `src/core/tecis-dokumente-datenbank.core.js` that contain the pure logic (DOM handling, parsing, business rules). 
- Added userscript adapters in `src/adapters/userscript/*.entry.js` that include Tampermonkey metadata and implement `fetchJson` via `GM.xmlHttpRequest` and `addCss` via `GM_addStyle` when available. 
- Added extension adapters in `src/adapters/extension/*.entry.js` that implement `fetchJson` via `chrome.runtime.sendMessage`, install page-context hooks (e.g. `page-window-open-hook.js`) and wire background proxying. 
- Added a simple bundling tool `build-targets.mjs` and a `npm` script `build:targets` (in `pars-pro-toto-BM-Autofill-chrome-extension/package.json`) that emits both variants into `dist/userscripts/*.user.js` and `dist/extension/content/*.js`, preserving userscript headers. 
- Updated GitHub Actions workflow `.github/workflows/main.yml` to run on `main`/`master` and to run the build step before the FTP deploy step.

### Testing
- Ran `npm --prefix pars-pro-toto-BM-Autofill-chrome-extension run build:targets` and the build completed and produced files in `dist/userscripts` and `dist/extension/content`. (succeeded)
- Performed syntax checks with `node --check` against the generated outputs `dist/userscripts/tecis-*.user.js` and `dist/extension/content/tecis-*.js` and all checks passed. (succeeded)
- Verified artifact file sizes / line counts in `dist/` to ensure outputs were generated (sanity check). (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2692970ac832d82d6cdb44d2d6304)