### PR TITLE
Handle CRLF and leading whitespace when extracting userscript headers and stripping imports

### DIFF
--- a/pars-pro-toto-BM-Autofill-chrome-extension/build-targets.mjs
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/build-targets.mjs
@@ -21,16 +21,16 @@ function read(path) {
 }
 
 function extractUserscriptHeader(source) {
-  const match = source.match(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==\n?/);
+  const match = source.match(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==\r?\n?/);
   return match ? match[0].trimEnd() + '\n\n' : '';
 }
 
 function stripUserscriptHeader(source) {
-  return source.replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==\n?\n?/, '');
+  return source.replace(/\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==\r?\n?\r?\n?/, '');
 }
 
 function stripImports(source) {
-  return source.replace(/^import\s+.+?;\n/gm, '');
+  return source.replace(/^\s*import\s+.+?;\r?$/gm, '');
 }
 
 function stripExports(source) {


### PR DESCRIPTION
### Motivation
- Ensure the build bundler correctly handles files that use Windows CRLF line endings and import lines with leading whitespace when extracting userscript headers and removing imports.

### Description
- Relaxed the regexes in `build-targets.mjs` by updating `extractUserscriptHeader` to accept `\r?\n?`, `stripUserscriptHeader` to remove optional CRLF sequences, and `stripImports` to match leading whitespace and optional CRLF using `/^\s*import\s+.+?;\r?$/gm`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c26ff5f5e8832d962fdefd47b284e2)