### PR TITLE
Adjust FTP deploy exclusions and resync strategy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,5 +23,11 @@ jobs:
           password: ${{ secrets.FTP_PASSWORD }}
           server-dir: /html/mopoliti.de/Userscripts/
           local-dir: ./
+          dangerous-clean-slate: true
           exclude: |
+            **/.git/**
+            **/.github/**
+            **/.idea/**
+            **/GoogleAppScripts/**
+            **/xlsm/**
             **/pars-pro-toto-BM-Autofill-chrome-extension/**


### PR DESCRIPTION
### Motivation
- Deploys were failing with remote-state mismatches (e.g. `550 Can't change directory ... No such file or directory`) when files or folders were removed on the server or auto-pruned. 
- Certain local folders should be excluded from uploads to avoid uploading private/irrelevant content and reduce mismatch risk, specifically `.git`, `.github`, `.idea`, `GoogleAppScripts`, and `xlsm`.

### Description
- Updated ` .github/workflows/main.yml` to add `dangerous-clean-slate: true` to the `SamKirkland/FTP-Deploy-Action@4.2.0` step so each deploy starts from a clean remote directory and does not rely on previous sync state.
- Added exclude patterns to the FTP deploy step for `**/.git/**`, `**/.github/**`, `**/.idea/**`, `**/GoogleAppScripts/**`, and `**/xlsm/**`, while keeping the existing `**/pars-pro-toto-BM-Autofill-chrome-extension/**` exclusion.
- Commit message: `Adjust FTP deploy exclusions and resync strategy`.

### Testing
- Ran `git diff -- .github/workflows/main.yml && git status --short` and inspected the diff, which showed the intended changes and returned successfully.
- Ran `git add .github/workflows/main.yml && git commit -m "Adjust FTP deploy exclusions and resync strategy"` and the commit completed successfully.
- Ran `nl -ba .github/workflows/main.yml | sed -n '1,200p'` to verify the file contents, which printed the updated workflow and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c27486e584832d90130b8f30a2bcd8)