### PR TITLE
Handle HTTP error responses in userscript fetch adapter

### DIFF
--- a/pars-pro-toto-BM-Autofill-chrome-extension/src/adapters/userscript/tecis-bm-gespraechsnotiz-autofill.entry.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/src/adapters/userscript/tecis-bm-gespraechsnotiz-autofill.entry.js
@@ -26,11 +26,27 @@ function fetchJson(url, { method = 'GET', headers = {}, body = null } = {}) {
       headers,
       data: body,
       onload: (response) => {
+        const status = typeof response.status === 'number' ? response.status : 200;
+        let parsedResponse;
         try {
-          resolve(JSON.parse(response.responseText));
+          parsedResponse = JSON.parse(response.responseText);
         } catch (error) {
-          reject(error);
+          if (status >= 200 && status < 300) {
+            reject(error);
+            return;
+          }
+          parsedResponse = response.responseText;
         }
+
+        if (status < 200 || status >= 300) {
+          const err = new Error(`HTTP ${status} for ${url}`);
+          err.status = status;
+          err.data = parsedResponse;
+          reject(err);
+          return;
+        }
+
+        resolve(parsedResponse);
       },
       onerror: reject,
     });


### PR DESCRIPTION
### Motivation
- The userscript `fetchJson` previously parsed and resolved JSON on `onload` without checking `response.status`, causing HTTP 5xx responses to be treated as successes. 
- Core logic in `initGespraechsnotizAutofillEditor` depends on adapter errors (`err.status === 500` and `err.data.errorType === "HAUSHALT_NOT_ACTIVE"`) to trigger an activation fallback. 
- Fixing the adapter ensures invalid/empty data from error responses does not silently bypass the activation retry flow.

### Description
- Update `src/adapters/userscript/tecis-bm-gespraechsnotiz-autofill.entry.js` to read `response.status` (defaulting to `200` when not present) and store a parsed payload in a local `parsedResponse` variable. 
- Treat non-2xx responses as errors by constructing an `Error` with `err.status` and `err.data` set to the parsed (or raw) response and rejecting the promise in those cases. 
- Preserve existing behavior for successful responses by rejecting JSON parse errors on 2xx responses and resolving parsed JSON on success, while allowing non-JSON error bodies to be included in the error context.

### Testing
- Ran `npm run build:targets` in the extension root and the build completed successfully (npm emitted a non-blocking env warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2728c1800832d9aac9907da250bc2)