### PR TITLE
docs: Generierte Dateien in AGENTS.md als nicht bearbeiten kennzeichnen

### DIFF
--- a/pars-pro-toto-BM-Autofill-chrome-extension/AGENTS.md
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/AGENTS.md
@@ -27,6 +27,21 @@
 - **PDF-Lib**: Lokal über `lib/pdf-lib.js` eingebunden, keine externe CDN-Abhängigkeit.
 - **Autofill XHR-Intercept**: Im Editor via DOM-Injection, weil Content-Scripts die Page-Context-XHR nicht patchen können.
 
+
+## Generierte Dateien (nicht manuell bearbeiten)
+- Änderungen **nur** in `src/` vornehmen (`src/core/` und `src/adapters/`).
+- Die folgenden Build-/Output-Dateien dürfen nicht direkt editiert werden:
+  - `content/tecis-bm-gespraechsnotiz-autofill.js`
+  - `content/tecis-dokumente-datenbank.js`
+  - `../tecis BM Gespraechsnotiz Autofill.user.js`
+  - `../tecis Dokumente Datenbank.user.js`
+  - `../dist/extension/content/tecis-bm-gespraechsnotiz-autofill.js`
+  - `../dist/extension/content/tecis-dokumente-datenbank.js`
+  - `../dist/userscripts/tecis-bm-gespraechsnotiz-autofill.user.js`
+  - `../dist/userscripts/tecis-dokumente-datenbank.user.js`
+- Nach Änderungen in `src/` müssen die Output-Dateien über den Build-Prozess (`build-targets.mjs`) neu erzeugt werden.
+- Diese Liste ist zu pflegen: Wenn neue generierte Dateien hinzukommen oder Pfade sich ändern, diese Anweisung sofort aktualisieren.
+
 ## Tests & Debugging
 - In Chrome unter `chrome://extensions` im Entwicklermodus laden ("Entpackte Erweiterung" → Ordner `tecis-chrome-extension`).
 - Service Worker Logs in der Extensions-Seite öffnen.


### PR DESCRIPTION
### Motivation
- Verhindern, dass automatisch erzeugte/build-Ausgabedateien versehentlich manuell bearbeitet werden; die Quelle der Wahrheit soll in `src/` liegen.

### Description
- Die Datei `pars-pro-toto-BM-Autofill-chrome-extension/AGENTS.md` wurde um den Abschnitt "Generierte Dateien (nicht manuell bearbeiten)" ergänzt, der die betroffenen Output-/Build-Dateien auflistet, darauf hinweist, Änderungen nur in `src/` (`src/core/` und `src/adapters/`) vorzunehmen und die Outputs nach Änderungen über `build-targets.mjs` neu zu erzeugen.

### Testing
- Automatisierte Prüfungen: `git -C /workspace/MyUserscripts status --short` zeigte die Änderung als modifiziert und die Änderung wurde committed (Commit-Nachricht: `docs: clarify generated files must not be edited`); es sind keine Laufzeit-Tests für diese dokumentations-only Änderung erforderlich.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c51c607a88832da323a146b13c0b71)