### PR TITLE
Fix missing autofill=true in extension new-tab flow

### DIFF
--- a/pars-pro-toto-BM-Autofill-chrome-extension/content/page-window-open-hook.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/content/page-window-open-hook.js
@@ -46,11 +46,17 @@
         }
     });
 
+    function setAutofillNextOpen() {
+        addAutofillNextOpen = true;
+    }
+
     window.addEventListener('message', (event) => {
-        if (event.source !== window) return;
+        // In some Chrome extension contexts `event.source` can be null.
         if (!event.data || event.data.source !== 'tecis-extension') return;
         if (event.data.type === 'set-autofill-next-open') {
-            addAutofillNextOpen = true;
+            setAutofillNextOpen();
         }
     });
+
+    window.addEventListener('tecis-extension:set-autofill-next-open', setAutofillNextOpen);
 })();

--- a/pars-pro-toto-BM-Autofill-chrome-extension/content/tecis-bm-gespraechsnotiz-autofill.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/content/tecis-bm-gespraechsnotiz-autofill.js
@@ -12,9 +12,14 @@ function initGespraechsnotizAutofillList({ installWindowOpenHook, signalPageAuto
     // -------- URL param helpers --------
     let addAutofillNextOpen = false; // one-shot flag for the next window.open()
 
-    function getCurrentWibiid() {
-        try { return new URL(location.href).searchParams.get("wibiid"); }
-        catch { return null; }
+    // Hilfsfunktion zum Abgreifen aller relevanten Parameter aus der aktuellen URL
+    function getContextParams() {
+        const params = new URLSearchParams(location.search);
+        return {
+            wibiid: params.get("wibiid"),
+            svhvnr: params.get("svhvnr"),
+            verkaufsbegleiter: params.get("verkaufsbegleiter")
+        };
     }
 
     function isNormalUrl(u) {
@@ -27,9 +32,16 @@ function initGespraechsnotizAutofillList({ installWindowOpenHook, signalPageAuto
         try { target = new URL(u, location.href); }
         catch { return u; }
 
-        const wibiid = getCurrentWibiid();
-        if (wibiid && !target.searchParams.has("wibiid")) {
-            target.searchParams.set("wibiid", wibiid);
+        const context = getContextParams();
+
+        if (context.wibiid && !target.searchParams.has("wibiid")) {
+            target.searchParams.set("wibiid", context.wibiid);
+        }
+        if (context.svhvnr && !target.searchParams.has("svhvnr")) {
+            target.searchParams.set("svhvnr", context.svhvnr);
+        }
+        if (context.verkaufsbegleiter && !target.searchParams.has("verkaufsbegleiter")) {
+            target.searchParams.set("verkaufsbegleiter", context.verkaufsbegleiter);
         }
         if (forceAutofill) {
             target.searchParams.set("autofill", "true");
@@ -139,7 +151,7 @@ function initGespraechsnotizAutofillList({ installWindowOpenHook, signalPageAuto
     }
 }
 
-// ===== BP Editor Autofill (wibiid) =====
+// ===== BP Editor Autofill (mit Berater-Kontext) =====
 function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromise }) {
     // Only run this block on the editor UI
     if (!location.href.startsWith("https://bm.bp.vertrieb-plattform.de/edocbox/editor/ui/")) return;
@@ -153,6 +165,26 @@ function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromis
     const qs = new URLSearchParams(window.location.search);
     const isAutoFill = (qs.get('autofill') || '').toLowerCase() === 'true';
     if(!isAutoFill) return;
+
+    // --- Dekodierung der Kontext-Parameter ---
+    function decodeBase64Url(b64) {
+        if (!b64) return '';
+        b64 = b64.replace(/-/g, '+').replace(/_/g, '/');
+        while (b64.length % 4) b64 += '=';
+        try {
+            return decodeURIComponent(Array.prototype.map.call(atob(b64), c =>
+                '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+            ).join(''));
+        } catch {
+            try { return atob(b64); } catch { return ''; }
+        }
+    }
+
+    const context = {
+        wibiid: decodeBase64Url(qs.get('wibiid') || '').trim(),
+        svhvnr: decodeBase64Url(qs.get('svhvnr') || '').trim(),
+        vkb: decodeBase64Url(qs.get('verkaufsbegleiter') || '').trim()
+    };
 
     // ------- Overlay Helper -------
     function updateOverlay(message = "Gesprächsnotiz wird vorausgefüllt") {
@@ -193,19 +225,6 @@ function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromis
     }
 
     const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-
-    function decodeBase64Url(b64) {
-        if (!b64) return '';
-        b64 = b64.replace(/-/g, '+').replace(/_/g, '/');
-        while (b64.length % 4) b64 += '=';
-        try {
-            return decodeURIComponent(Array.prototype.map.call(atob(b64), c =>
-                '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
-            ).join(''));
-        } catch (e) {
-            try { return atob(b64); } catch { return ''; }
-        }
-    }
 
     function gmFetchJson(url, { method = 'GET', headers = {}, body = null, withCredentials = true } = {}) {
         return fetchJson(url, { method, headers, body, withCredentials })
@@ -902,7 +921,7 @@ function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromis
         updateOverlay("Starte Autofill...");
 
         let pageData;
-        const wibiid = decodeBase64Url(qs.get('wibiid') || '').trim();
+        const wibiid = context.wibiid;
 
         // Schritt 1: Lade die grundlegenden Dokument-Daten. Dies ist immer notwendig.
         try {
@@ -1017,6 +1036,7 @@ function installWindowOpenHook() {
 
 function signalPageAutofillNextOpen() {
   window.postMessage({ source: 'tecis-extension', type: 'set-autofill-next-open' }, '*');
+  window.dispatchEvent(new CustomEvent('tecis-extension:set-autofill-next-open'));
 }
 
 function createDocumentJsonPromise() {

--- a/pars-pro-toto-BM-Autofill-chrome-extension/src/adapters/extension/tecis-bm-gespraechsnotiz-autofill.entry.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/src/adapters/extension/tecis-bm-gespraechsnotiz-autofill.entry.js
@@ -39,6 +39,7 @@ function installWindowOpenHook() {
 
 function signalPageAutofillNextOpen() {
   window.postMessage({ source: 'tecis-extension', type: 'set-autofill-next-open' }, '*');
+  window.dispatchEvent(new CustomEvent('tecis-extension:set-autofill-next-open'));
 }
 
 function createDocumentJsonPromise() {

--- a/tecis BM Gespraechsnotiz Autofill.user.js
+++ b/tecis BM Gespraechsnotiz Autofill.user.js
@@ -29,9 +29,14 @@ function initGespraechsnotizAutofillList({ installWindowOpenHook, signalPageAuto
     // -------- URL param helpers --------
     let addAutofillNextOpen = false; // one-shot flag for the next window.open()
 
-    function getCurrentWibiid() {
-        try { return new URL(location.href).searchParams.get("wibiid"); }
-        catch { return null; }
+    // Hilfsfunktion zum Abgreifen aller relevanten Parameter aus der aktuellen URL
+    function getContextParams() {
+        const params = new URLSearchParams(location.search);
+        return {
+            wibiid: params.get("wibiid"),
+            svhvnr: params.get("svhvnr"),
+            verkaufsbegleiter: params.get("verkaufsbegleiter")
+        };
     }
 
     function isNormalUrl(u) {
@@ -44,9 +49,16 @@ function initGespraechsnotizAutofillList({ installWindowOpenHook, signalPageAuto
         try { target = new URL(u, location.href); }
         catch { return u; }
 
-        const wibiid = getCurrentWibiid();
-        if (wibiid && !target.searchParams.has("wibiid")) {
-            target.searchParams.set("wibiid", wibiid);
+        const context = getContextParams();
+
+        if (context.wibiid && !target.searchParams.has("wibiid")) {
+            target.searchParams.set("wibiid", context.wibiid);
+        }
+        if (context.svhvnr && !target.searchParams.has("svhvnr")) {
+            target.searchParams.set("svhvnr", context.svhvnr);
+        }
+        if (context.verkaufsbegleiter && !target.searchParams.has("verkaufsbegleiter")) {
+            target.searchParams.set("verkaufsbegleiter", context.verkaufsbegleiter);
         }
         if (forceAutofill) {
             target.searchParams.set("autofill", "true");
@@ -156,7 +168,7 @@ function initGespraechsnotizAutofillList({ installWindowOpenHook, signalPageAuto
     }
 }
 
-// ===== BP Editor Autofill (wibiid) =====
+// ===== BP Editor Autofill (mit Berater-Kontext) =====
 function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromise }) {
     // Only run this block on the editor UI
     if (!location.href.startsWith("https://bm.bp.vertrieb-plattform.de/edocbox/editor/ui/")) return;
@@ -170,6 +182,26 @@ function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromis
     const qs = new URLSearchParams(window.location.search);
     const isAutoFill = (qs.get('autofill') || '').toLowerCase() === 'true';
     if(!isAutoFill) return;
+
+    // --- Dekodierung der Kontext-Parameter ---
+    function decodeBase64Url(b64) {
+        if (!b64) return '';
+        b64 = b64.replace(/-/g, '+').replace(/_/g, '/');
+        while (b64.length % 4) b64 += '=';
+        try {
+            return decodeURIComponent(Array.prototype.map.call(atob(b64), c =>
+                '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+            ).join(''));
+        } catch {
+            try { return atob(b64); } catch { return ''; }
+        }
+    }
+
+    const context = {
+        wibiid: decodeBase64Url(qs.get('wibiid') || '').trim(),
+        svhvnr: decodeBase64Url(qs.get('svhvnr') || '').trim(),
+        vkb: decodeBase64Url(qs.get('verkaufsbegleiter') || '').trim()
+    };
 
     // ------- Overlay Helper -------
     function updateOverlay(message = "Gesprächsnotiz wird vorausgefüllt") {
@@ -210,19 +242,6 @@ function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromis
     }
 
     const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-
-    function decodeBase64Url(b64) {
-        if (!b64) return '';
-        b64 = b64.replace(/-/g, '+').replace(/_/g, '/');
-        while (b64.length % 4) b64 += '=';
-        try {
-            return decodeURIComponent(Array.prototype.map.call(atob(b64), c =>
-                '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
-            ).join(''));
-        } catch (e) {
-            try { return atob(b64); } catch { return ''; }
-        }
-    }
 
     function gmFetchJson(url, { method = 'GET', headers = {}, body = null, withCredentials = true } = {}) {
         return fetchJson(url, { method, headers, body, withCredentials })
@@ -919,7 +938,7 @@ function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromis
         updateOverlay("Starte Autofill...");
 
         let pageData;
-        const wibiid = decodeBase64Url(qs.get('wibiid') || '').trim();
+        const wibiid = context.wibiid;
 
         // Schritt 1: Lade die grundlegenden Dokument-Daten. Dies ist immer notwendig.
         try {
@@ -1004,11 +1023,27 @@ function fetchJson(url, { method = 'GET', headers = {}, body = null } = {}) {
       headers,
       data: body,
       onload: (response) => {
+        const status = typeof response.status === 'number' ? response.status : 200;
+        let parsedResponse;
         try {
-          resolve(JSON.parse(response.responseText));
+          parsedResponse = JSON.parse(response.responseText);
         } catch (error) {
-          reject(error);
+          if (status >= 200 && status < 300) {
+            reject(error);
+            return;
+          }
+          parsedResponse = response.responseText;
         }
+
+        if (status < 200 || status >= 300) {
+          const err = new Error(`HTTP ${status} for ${url}`);
+          err.status = status;
+          err.data = parsedResponse;
+          reject(err);
+          return;
+        }
+
+        resolve(parsedResponse);
       },
       onerror: reject,
     });


### PR DESCRIPTION
### Motivation
- New-tab navigations opened by the extension lost the one-shot `autofill=true` flag because the page-context hook did not always receive the `postMessage` from the extension in some Chrome contexts.
- The injected `window.open` hook relied on `event.source === window`, which can be null for extension messages, causing the flag handoff to fail.

### Description
- Added a CustomEvent fallback in the extension adapter so the extension signals the autofill flag via both `window.postMessage(...)` and `window.dispatchEvent(new CustomEvent('tecis-extension:set-autofill-next-open'))` in `src/adapters/extension/tecis-bm-gespraechsnotiz-autofill.entry.js`.
- Hardened the injected page hook in `content/page-window-open-hook.js` by relaxing the `event.source` check and introducing a shared `setAutofillNextOpen` handler that is invoked from both the `message` listener and the `tecis-extension:set-autofill-next-open` CustomEvent listener.
- Rebuilt generated outputs so the shipped extension and legacy userscript include the new signaling path; updated generated files include `content/tecis-bm-gespraechsnotiz-autofill.js` and `tecis BM Gespraechsnotiz Autofill.user.js`.

### Testing
- Ran `npm run build:targets` in `pars-pro-toto-BM-Autofill-chrome-extension` which completed successfully and updated `dist/` and generated outputs.
- Verified repository status with `git status --short` to confirm generated outputs were updated (no blocking issues observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c587e5fa94832db59110978bd88744)