### PR TITLE
Propagate advisor context (wibiid/svhvnr/verkaufsbegleiter), inject page hook and harden messaging/parsing

### DIFF
--- a/pars-pro-toto-BM-Autofill-chrome-extension/content/page-window-open-hook.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/content/page-window-open-hook.js
@@ -46,11 +46,17 @@
         }
     });
 
+    function setAutofillNextOpen() {
+        addAutofillNextOpen = true;
+    }
+
     window.addEventListener('message', (event) => {
-        if (event.source !== window) return;
+        // In some Chrome extension contexts `event.source` can be null.
         if (!event.data || event.data.source !== 'tecis-extension') return;
         if (event.data.type === 'set-autofill-next-open') {
-            addAutofillNextOpen = true;
+            setAutofillNextOpen();
         }
     });
+
+    window.addEventListener('tecis-extension:set-autofill-next-open', setAutofillNextOpen);
 })();

--- a/pars-pro-toto-BM-Autofill-chrome-extension/content/tecis-bm-gespraechsnotiz-autofill.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/content/tecis-bm-gespraechsnotiz-autofill.js
@@ -12,9 +12,14 @@ function initGespraechsnotizAutofillList({ installWindowOpenHook, signalPageAuto
     // -------- URL param helpers --------
     let addAutofillNextOpen = false; // one-shot flag for the next window.open()
 
-    function getCurrentWibiid() {
-        try { return new URL(location.href).searchParams.get("wibiid"); }
-        catch { return null; }
+    // Hilfsfunktion zum Abgreifen aller relevanten Parameter aus der aktuellen URL
+    function getContextParams() {
+        const params = new URLSearchParams(location.search);
+        return {
+            wibiid: params.get("wibiid"),
+            svhvnr: params.get("svhvnr"),
+            verkaufsbegleiter: params.get("verkaufsbegleiter")
+        };
     }
 
     function isNormalUrl(u) {
@@ -27,9 +32,16 @@ function initGespraechsnotizAutofillList({ installWindowOpenHook, signalPageAuto
         try { target = new URL(u, location.href); }
         catch { return u; }
 
-        const wibiid = getCurrentWibiid();
-        if (wibiid && !target.searchParams.has("wibiid")) {
-            target.searchParams.set("wibiid", wibiid);
+        const context = getContextParams();
+
+        if (context.wibiid && !target.searchParams.has("wibiid")) {
+            target.searchParams.set("wibiid", context.wibiid);
+        }
+        if (context.svhvnr && !target.searchParams.has("svhvnr")) {
+            target.searchParams.set("svhvnr", context.svhvnr);
+        }
+        if (context.verkaufsbegleiter && !target.searchParams.has("verkaufsbegleiter")) {
+            target.searchParams.set("verkaufsbegleiter", context.verkaufsbegleiter);
         }
         if (forceAutofill) {
             target.searchParams.set("autofill", "true");
@@ -139,7 +151,7 @@ function initGespraechsnotizAutofillList({ installWindowOpenHook, signalPageAuto
     }
 }
 
-// ===== BP Editor Autofill (wibiid) =====
+// ===== BP Editor Autofill (mit Berater-Kontext) =====
 function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromise }) {
     // Only run this block on the editor UI
     if (!location.href.startsWith("https://bm.bp.vertrieb-plattform.de/edocbox/editor/ui/")) return;
@@ -153,6 +165,26 @@ function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromis
     const qs = new URLSearchParams(window.location.search);
     const isAutoFill = (qs.get('autofill') || '').toLowerCase() === 'true';
     if(!isAutoFill) return;
+
+    // --- Dekodierung der Kontext-Parameter ---
+    function decodeBase64Url(b64) {
+        if (!b64) return '';
+        b64 = b64.replace(/-/g, '+').replace(/_/g, '/');
+        while (b64.length % 4) b64 += '=';
+        try {
+            return decodeURIComponent(Array.prototype.map.call(atob(b64), c =>
+                '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+            ).join(''));
+        } catch {
+            try { return atob(b64); } catch { return ''; }
+        }
+    }
+
+    const context = {
+        wibiid: decodeBase64Url(qs.get('wibiid') || '').trim(),
+        svhvnr: decodeBase64Url(qs.get('svhvnr') || '').trim(),
+        vkb: decodeBase64Url(qs.get('verkaufsbegleiter') || '').trim()
+    };
 
     // ------- Overlay Helper -------
     function updateOverlay(message = "Gesprächsnotiz wird vorausgefüllt") {
@@ -193,19 +225,6 @@ function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromis
     }
 
     const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-
-    function decodeBase64Url(b64) {
-        if (!b64) return '';
-        b64 = b64.replace(/-/g, '+').replace(/_/g, '/');
-        while (b64.length % 4) b64 += '=';
-        try {
-            return decodeURIComponent(Array.prototype.map.call(atob(b64), c =>
-                '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
-            ).join(''));
-        } catch (e) {
-            try { return atob(b64); } catch { return ''; }
-        }
-    }
 
     function gmFetchJson(url, { method = 'GET', headers = {}, body = null, withCredentials = true } = {}) {
         return fetchJson(url, { method, headers, body, withCredentials })
@@ -902,7 +921,7 @@ function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromis
         updateOverlay("Starte Autofill...");
 
         let pageData;
-        const wibiid = decodeBase64Url(qs.get('wibiid') || '').trim();
+        const wibiid = context.wibiid;
 
         // Schritt 1: Lade die grundlegenden Dokument-Daten. Dies ist immer notwendig.
         try {
@@ -1008,15 +1027,13 @@ function fetchJson(url, { method = 'GET', headers = {}, body = null, withCredent
 }
 
 function installWindowOpenHook() {
-  const script = document.createElement('script');
-  script.src = chrome.runtime.getURL('content/page-window-open-hook.js');
-  script.async = false;
-  (document.head || document.documentElement).appendChild(script);
-  script.onload = () => script.remove();
+  // The page-context hook is injected directly via manifest content_scripts (world: MAIN).
+  // Keep this as a no-op to satisfy the shared core interface.
 }
 
 function signalPageAutofillNextOpen() {
   window.postMessage({ source: 'tecis-extension', type: 'set-autofill-next-open' }, '*');
+  window.dispatchEvent(new CustomEvent('tecis-extension:set-autofill-next-open'));
 }
 
 function createDocumentJsonPromise() {

--- a/pars-pro-toto-BM-Autofill-chrome-extension/manifest.json
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/manifest.json
@@ -32,6 +32,12 @@
   "content_scripts": [
     {
       "matches": ["https://bm.bp.vertrieb-plattform.de/bm/*"],
+      "js": ["content/page-window-open-hook.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
+    {
+      "matches": ["https://bm.bp.vertrieb-plattform.de/bm/*"],
       "js": ["content/tecis-bm-gespraechsnotiz-autofill.js"],
       "run_at": "document_start"
     },
@@ -51,10 +57,5 @@
       "run_at": "document_idle"
     }
   ],
-  "web_accessible_resources": [
-    {
-      "resources": ["content/page-window-open-hook.js"],
-      "matches": ["https://bm.bp.vertrieb-plattform.de/*"]
-    }
-  ]
+  "web_accessible_resources": []
 }

--- a/pars-pro-toto-BM-Autofill-chrome-extension/src/adapters/extension/tecis-bm-gespraechsnotiz-autofill.entry.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/src/adapters/extension/tecis-bm-gespraechsnotiz-autofill.entry.js
@@ -30,15 +30,13 @@ function fetchJson(url, { method = 'GET', headers = {}, body = null, withCredent
 }
 
 function installWindowOpenHook() {
-  const script = document.createElement('script');
-  script.src = chrome.runtime.getURL('content/page-window-open-hook.js');
-  script.async = false;
-  (document.head || document.documentElement).appendChild(script);
-  script.onload = () => script.remove();
+  // The page-context hook is injected directly via manifest content_scripts (world: MAIN).
+  // Keep this as a no-op to satisfy the shared core interface.
 }
 
 function signalPageAutofillNextOpen() {
   window.postMessage({ source: 'tecis-extension', type: 'set-autofill-next-open' }, '*');
+  window.dispatchEvent(new CustomEvent('tecis-extension:set-autofill-next-open'));
 }
 
 function createDocumentJsonPromise() {

--- a/tecis BM Gespraechsnotiz Autofill.user.js
+++ b/tecis BM Gespraechsnotiz Autofill.user.js
@@ -29,9 +29,14 @@ function initGespraechsnotizAutofillList({ installWindowOpenHook, signalPageAuto
     // -------- URL param helpers --------
     let addAutofillNextOpen = false; // one-shot flag for the next window.open()
 
-    function getCurrentWibiid() {
-        try { return new URL(location.href).searchParams.get("wibiid"); }
-        catch { return null; }
+    // Hilfsfunktion zum Abgreifen aller relevanten Parameter aus der aktuellen URL
+    function getContextParams() {
+        const params = new URLSearchParams(location.search);
+        return {
+            wibiid: params.get("wibiid"),
+            svhvnr: params.get("svhvnr"),
+            verkaufsbegleiter: params.get("verkaufsbegleiter")
+        };
     }
 
     function isNormalUrl(u) {
@@ -44,9 +49,16 @@ function initGespraechsnotizAutofillList({ installWindowOpenHook, signalPageAuto
         try { target = new URL(u, location.href); }
         catch { return u; }
 
-        const wibiid = getCurrentWibiid();
-        if (wibiid && !target.searchParams.has("wibiid")) {
-            target.searchParams.set("wibiid", wibiid);
+        const context = getContextParams();
+
+        if (context.wibiid && !target.searchParams.has("wibiid")) {
+            target.searchParams.set("wibiid", context.wibiid);
+        }
+        if (context.svhvnr && !target.searchParams.has("svhvnr")) {
+            target.searchParams.set("svhvnr", context.svhvnr);
+        }
+        if (context.verkaufsbegleiter && !target.searchParams.has("verkaufsbegleiter")) {
+            target.searchParams.set("verkaufsbegleiter", context.verkaufsbegleiter);
         }
         if (forceAutofill) {
             target.searchParams.set("autofill", "true");
@@ -156,7 +168,7 @@ function initGespraechsnotizAutofillList({ installWindowOpenHook, signalPageAuto
     }
 }
 
-// ===== BP Editor Autofill (wibiid) =====
+// ===== BP Editor Autofill (mit Berater-Kontext) =====
 function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromise }) {
     // Only run this block on the editor UI
     if (!location.href.startsWith("https://bm.bp.vertrieb-plattform.de/edocbox/editor/ui/")) return;
@@ -170,6 +182,26 @@ function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromis
     const qs = new URLSearchParams(window.location.search);
     const isAutoFill = (qs.get('autofill') || '').toLowerCase() === 'true';
     if(!isAutoFill) return;
+
+    // --- Dekodierung der Kontext-Parameter ---
+    function decodeBase64Url(b64) {
+        if (!b64) return '';
+        b64 = b64.replace(/-/g, '+').replace(/_/g, '/');
+        while (b64.length % 4) b64 += '=';
+        try {
+            return decodeURIComponent(Array.prototype.map.call(atob(b64), c =>
+                '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+            ).join(''));
+        } catch {
+            try { return atob(b64); } catch { return ''; }
+        }
+    }
+
+    const context = {
+        wibiid: decodeBase64Url(qs.get('wibiid') || '').trim(),
+        svhvnr: decodeBase64Url(qs.get('svhvnr') || '').trim(),
+        vkb: decodeBase64Url(qs.get('verkaufsbegleiter') || '').trim()
+    };
 
     // ------- Overlay Helper -------
     function updateOverlay(message = "Gesprächsnotiz wird vorausgefüllt") {
@@ -210,19 +242,6 @@ function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromis
     }
 
     const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-
-    function decodeBase64Url(b64) {
-        if (!b64) return '';
-        b64 = b64.replace(/-/g, '+').replace(/_/g, '/');
-        while (b64.length % 4) b64 += '=';
-        try {
-            return decodeURIComponent(Array.prototype.map.call(atob(b64), c =>
-                '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
-            ).join(''));
-        } catch (e) {
-            try { return atob(b64); } catch { return ''; }
-        }
-    }
 
     function gmFetchJson(url, { method = 'GET', headers = {}, body = null, withCredentials = true } = {}) {
         return fetchJson(url, { method, headers, body, withCredentials })
@@ -919,7 +938,7 @@ function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromis
         updateOverlay("Starte Autofill...");
 
         let pageData;
-        const wibiid = decodeBase64Url(qs.get('wibiid') || '').trim();
+        const wibiid = context.wibiid;
 
         // Schritt 1: Lade die grundlegenden Dokument-Daten. Dies ist immer notwendig.
         try {
@@ -1004,11 +1023,27 @@ function fetchJson(url, { method = 'GET', headers = {}, body = null } = {}) {
       headers,
       data: body,
       onload: (response) => {
+        const status = typeof response.status === 'number' ? response.status : 200;
+        let parsedResponse;
         try {
-          resolve(JSON.parse(response.responseText));
+          parsedResponse = JSON.parse(response.responseText);
         } catch (error) {
-          reject(error);
+          if (status >= 200 && status < 300) {
+            reject(error);
+            return;
+          }
+          parsedResponse = response.responseText;
         }
+
+        if (status < 200 || status >= 300) {
+          const err = new Error(`HTTP ${status} for ${url}`);
+          err.status = status;
+          err.data = parsedResponse;
+          reject(err);
+          return;
+        }
+
+        resolve(parsedResponse);
       },
       onerror: reject,
     });


### PR DESCRIPTION
### Motivation
- Ensure additional advisor/context parameters (`wibiid`, `svhvnr`, `verkaufsbegleiter`) are propagated when opening editor windows so Autofill has the full context. 
- Move the `window.open` hook into the page/Main world to reliably intercept PrimeFaces flows and make the page<->content signaling more robust across Chrome extension contexts. 
- Harden cross-context messaging and JSON parsing to avoid failures when `event.source` is null or responses are non-JSON.

### Description
- Inject `content/page-window-open-hook.js` as a `content_scripts` entry with `run_at: document_start` and `world: MAIN`, and remove the previous `web_accessible_resources` usage for that file.  
- Make the injected hook expose a `setAutofillNextOpen` helper and tolerate `event.source === null`, and add a `CustomEvent` listener so page and content scripts can reliably trigger the one-shot `autofill` flag.  
- Convert `installWindowOpenHook()` in extension bundles to a no-op (the hook is injected via the manifest) and update `signalPageAutofillNextOpen()` to both `postMessage` and dispatch a `CustomEvent('tecis-extension:set-autofill-next-open')`.  
- Add `getContextParams()` to list-side code and propagate `wibiid`, `svhvnr` and `verkaufsbegleiter` when building URLs; add base64 decoding and a `context` object in the editor autofill flow to read these parameters there.  
- Improve userscript `fetchJson` handling to properly detect HTTP status, return parsed JSON when possible, and surface HTTP errors with status and body when non-2xx responses occur.

### Testing
- Ran the project build with `npm run build`, which completed successfully. 
- Ran unit tests with `npm test`, and all tests passed. 
- Ran linter via `npm run lint`, which succeeded without new issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c587e5fa94832db59110978bd88744)