### PR TITLE
Add x-betreuer-hv-nr header for Startkonzept Haushalt API requests

### DIFF
--- a/pars-pro-toto-BM-Autofill-chrome-extension/content/tecis-bm-gespraechsnotiz-autofill.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/content/tecis-bm-gespraechsnotiz-autofill.js
@@ -227,7 +227,15 @@ function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromis
     const sleep = (ms) => new Promise(r => setTimeout(r, ms));
 
     function gmFetchJson(url, { method = 'GET', headers = {}, body = null, withCredentials = true } = {}) {
-        return fetchJson(url, { method, headers, body, withCredentials })
+        const requestHeaders = { ...headers };
+        const hasAbweichenderBetreuer = !!context.vkb && !!context.svhvnr && context.vkb !== context.svhvnr;
+        const isHaushaltApiRequest = /^https:\/\/startkonzept\.bp\.vertrieb-plattform\.de\/api\/haushalt(?:\/|\?|$)/.test(url);
+
+        if (hasAbweichenderBetreuer && isHaushaltApiRequest) {
+            requestHeaders['x-betreuer-hv-nr'] = context.svhvnr;
+        }
+
+        return fetchJson(url, { method, headers: requestHeaders, body, withCredentials })
             .catch((err) => {
                 if (err.status === 500 && err.data && err.data.errorType === "HAUSHALT_NOT_ACTIVE") {
                     const customErr = new Error("HAUSHALT_NOT_ACTIVE");

--- a/pars-pro-toto-BM-Autofill-chrome-extension/src/core/tecis-bm-gespraechsnotiz-autofill.core.js
+++ b/pars-pro-toto-BM-Autofill-chrome-extension/src/core/tecis-bm-gespraechsnotiz-autofill.core.js
@@ -221,7 +221,15 @@ export function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJso
     const sleep = (ms) => new Promise(r => setTimeout(r, ms));
 
     function gmFetchJson(url, { method = 'GET', headers = {}, body = null, withCredentials = true } = {}) {
-        return fetchJson(url, { method, headers, body, withCredentials })
+        const requestHeaders = { ...headers };
+        const hasAbweichenderBetreuer = !!context.vkb && !!context.svhvnr && context.vkb !== context.svhvnr;
+        const isHaushaltApiRequest = /^https:\/\/startkonzept\.bp\.vertrieb-plattform\.de\/api\/haushalt(?:\/|\?|$)/.test(url);
+
+        if (hasAbweichenderBetreuer && isHaushaltApiRequest) {
+            requestHeaders['x-betreuer-hv-nr'] = context.svhvnr;
+        }
+
+        return fetchJson(url, { method, headers: requestHeaders, body, withCredentials })
             .catch((err) => {
                 if (err.status === 500 && err.data && err.data.errorType === "HAUSHALT_NOT_ACTIVE") {
                     const customErr = new Error("HAUSHALT_NOT_ACTIVE");

--- a/tecis BM Gespraechsnotiz Autofill.user.js
+++ b/tecis BM Gespraechsnotiz Autofill.user.js
@@ -244,7 +244,15 @@ function initGespraechsnotizAutofillEditor({ fetchJson, createDocumentJsonPromis
     const sleep = (ms) => new Promise(r => setTimeout(r, ms));
 
     function gmFetchJson(url, { method = 'GET', headers = {}, body = null, withCredentials = true } = {}) {
-        return fetchJson(url, { method, headers, body, withCredentials })
+        const requestHeaders = { ...headers };
+        const hasAbweichenderBetreuer = !!context.vkb && !!context.svhvnr && context.vkb !== context.svhvnr;
+        const isHaushaltApiRequest = /^https:\/\/startkonzept\.bp\.vertrieb-plattform\.de\/api\/haushalt(?:\/|\?|$)/.test(url);
+
+        if (hasAbweichenderBetreuer && isHaushaltApiRequest) {
+            requestHeaders['x-betreuer-hv-nr'] = context.svhvnr;
+        }
+
+        return fetchJson(url, { method, headers: requestHeaders, body, withCredentials })
             .catch((err) => {
                 if (err.status === 500 && err.data && err.data.errorType === "HAUSHALT_NOT_ACTIVE") {
                     const customErr = new Error("HAUSHALT_NOT_ACTIVE");


### PR DESCRIPTION
### Motivation

- Ensure API calls to the Startkonzept Haushalt endpoints use the correct betreuer identifier when the current context indicates a different Betreuer (when `context.vkb !== context.svhvnr`).

### Description

- Injects an `x-betreuer-hv-nr` header into requests to `https://startkonzept.bp.vertrieb-plattform.de/api/haushalt` when `context.vkb` and `context.svhvnr` are present and different by updating `gmFetchJson`.
- Detects Startkonzept Haushalt requests with a regex and builds `requestHeaders` from the provided `headers` before adding the custom header when applicable.
- Preserves existing error mapping for `HAUSHALT_NOT_ACTIVE` by continuing to convert the API error into a thrown `Error` with `isHaushaltNotActive` set.
- Applied the change in three locations: `content/tecis-bm-gespraechsnotiz-autofill.js`, `src/core/tecis-bm-gespraechsnotiz-autofill.core.js`, and `tecis BM Gespraechsnotiz Autofill.user.js` to keep runtime and build artifacts consistent.

### Testing

- Ran the existing automated test suite and project build locally; all tests and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5910a55e4832d99cb4a2d404e5b60)